### PR TITLE
Show some Game Info

### DIFF
--- a/D-OS Save Editor/D-OS Save Editor.csproj
+++ b/D-OS Save Editor/D-OS Save Editor.csproj
@@ -104,6 +104,7 @@
     <Compile Include="ProgressIndicator.xaml.cs">
       <DependentUpon>ProgressIndicator.xaml</DependentUpon>
     </Compile>
+    <Compile Include="savegame\Meta.cs" />
     <Compile Include="savegame\Talent.cs" />
     <Compile Include="SE\AbilitiesTab.xaml.cs">
       <DependentUpon>AbilitiesTab.xaml</DependentUpon>
@@ -115,6 +116,9 @@
       <DependentUpon>AddBoostDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="savegame\DataTable.cs" />
+    <Compile Include="SE\GameInfoTab.xaml.cs">
+      <DependentUpon>GameInfoTab.xaml</DependentUpon>
+    </Compile>
     <Compile Include="SE\InventoryTab.xaml.cs">
       <DependentUpon>InventoryTab.xaml</DependentUpon>
     </Compile>
@@ -158,6 +162,10 @@
     <Page Include="SE\AddBoostDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="SE\GameInfoTab.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="SE\InventoryTab.xaml">
       <SubType>Designer</SubType>

--- a/D-OS Save Editor/SE/GameInfoTab.xaml
+++ b/D-OS Save Editor/SE/GameInfoTab.xaml
@@ -1,0 +1,54 @@
+﻿<UserControl x:Class="D_OS_Save_Editor.GameInfoTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:D_OS_Save_Editor"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <Style TargetType="Grid">
+            <Setter Property="Margin" Value="10,0,10,10"/>
+        </Style>
+        <Style TargetType="RowDefinition">
+            <Setter Property="Height" Value="Auto"/>
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="3"/>
+        </Style>
+    </UserControl.Resources>
+    <WrapPanel>
+        <GroupBox Header="Info">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <TextBlock Text="Difficulty:" />
+                <TextBlock Text="SaveGame type:" Grid.Row="1"/>
+                <TextBlock Text="Seed:" Grid.Row="2"/>
+                <TextBlock Text="Map:" Grid.Row="3"/>
+                <TextBlock Text="Recording date:" Grid.Row="4"/>
+                <TextBlock x:Name="DifficultyTextBlock" Grid.Column="1"/>
+                <TextBlock x:Name="SaveGameTypeTextBlock" Grid.Row="1" Grid.Column="1"/>
+                <TextBlock x:Name="SeedTextBlock" Grid.Row="2" Grid.Column="1"/>
+                <TextBlock x:Name="LevelTextBlock" Grid.Row="3" Grid.Column="1"/>
+                <TextBlock x:Name="SaveTimeTextBlock" Grid.Row="4" Grid.Column="1"/>
+            </Grid>
+        </GroupBox>
+        <GroupBox Header="Game Version">
+            <ListBox x:Name="GameVersionListBox" Grid.Row="1" Grid.RowSpan="3" HorizontalAlignment="Left" MinHeight="200" Height="Auto" VerticalAlignment="Top" Width="133" IsEnabled="False" />
+        </GroupBox>
+        <GroupBox Header="Mods">
+            <ListBox x:Name="ModsListBox" Grid.Row="1" Grid.RowSpan="3" HorizontalAlignment="Left" MinHeight="200" Height="Auto" VerticalAlignment="Top" Width="166" IsEnabled="False" />
+        </GroupBox>
+    </WrapPanel>
+</UserControl>

--- a/D-OS Save Editor/SE/GameInfoTab.xaml.cs
+++ b/D-OS Save Editor/SE/GameInfoTab.xaml.cs
@@ -1,0 +1,55 @@
+﻿
+
+using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace D_OS_Save_Editor
+{
+    /// <summary>
+    /// Logique d'interaction pour GameInfoTab.xaml
+    /// </summary>
+    public partial class GameInfoTab
+    {
+        private string[] difficultyName = { "Story", "Classic", "Tactician", "Honour" };
+        private string[] gameSavetypeName = { "Manual","QuickSave","AutoSave","Honour Save" };
+
+        private Meta _meta;
+
+        public Meta Meta
+        {
+            get => _meta; set
+            {
+                _meta = value;
+                UpdateForm();
+            }
+        }
+
+        public GameInfoTab()
+        {
+            InitializeComponent();
+        }
+
+        public void UpdateForm()
+        {
+            DifficultyTextBlock.Text = difficultyName[Meta.Difficulty];
+            LevelTextBlock.Text = Meta.Level;
+            SaveTimeTextBlock.Text = Meta.SaveTime;
+            SeedTextBlock.Text = Meta.Seed;
+            SaveGameTypeTextBlock.Text = gameSavetypeName[Meta.SaveGameType];
+            foreach (string i in Meta.GameVersion)
+            {
+                if (GameVersionListBox.Items.Count == 0)
+                    GameVersionListBox.Items.Add(new ListBoxItem { Content = i });
+            }
+            foreach (string i in Meta.ModsName)
+            {
+                if (ModsListBox.Items.Count == 0)
+                    ModsListBox.Items.Add(new ListBoxItem { Content = i });
+            }
+        }
+    }
+
+
+}

--- a/D-OS Save Editor/SE/GameInfoTab.xaml.cs
+++ b/D-OS Save Editor/SE/GameInfoTab.xaml.cs
@@ -13,7 +13,7 @@ namespace D_OS_Save_Editor
     public partial class GameInfoTab
     {
         private string[] difficultyName = { "Story", "Classic", "Tactician", "Honour" };
-        private string[] gameSavetypeName = { "Manual","QuickSave","AutoSave","Honour Save" };
+        private string[] gameSavetypeName = { "Manual", "QuickSave", "AutoSave", "Honour Save" };
 
         private Meta _meta;
 
@@ -38,16 +38,18 @@ namespace D_OS_Save_Editor
             SaveTimeTextBlock.Text = Meta.SaveTime;
             SeedTextBlock.Text = Meta.Seed;
             SaveGameTypeTextBlock.Text = gameSavetypeName[Meta.SaveGameType];
-            foreach (string i in Meta.GameVersion)
-            {
-                if (GameVersionListBox.Items.Count == 0)
+            if (GameVersionListBox.Items.Count == 0)
+                foreach (string i in Meta.GameVersion)
+                {
+
                     GameVersionListBox.Items.Add(new ListBoxItem { Content = i });
-            }
-            foreach (string i in Meta.ModsName)
-            {
-                if (ModsListBox.Items.Count == 0)
+                }
+            if (ModsListBox.Items.Count == 0)
+                foreach (string i in Meta.ModsName)
+                {
+
                     ModsListBox.Items.Add(new ListBoxItem { Content = i });
-            }
+                }
         }
     }
 

--- a/D-OS Save Editor/SE/SaveEditor.xaml
+++ b/D-OS Save Editor/SE/SaveEditor.xaml
@@ -120,6 +120,9 @@
             <TabItem Header="Inventory">
                 <local:InventoryTab x:Name="InventoryTab" Margin="10"/>
             </TabItem>
+            <TabItem Header="Game Info">
+                <local:GameInfoTab x:Name="GameInfoTab" Margin="10"/>
+            </TabItem>
             <TabItem Header="Debug" Visibility="Collapsed">
                 <TabItem.Resources>
                     <Style TargetType="Button">

--- a/D-OS Save Editor/SE/SaveEditor.xaml.cs
+++ b/D-OS Save Editor/SE/SaveEditor.xaml.cs
@@ -17,6 +17,8 @@ namespace D_OS_Save_Editor
     {
         private Savegame Savegame { get; set; }
         private Player[] EditingPlayers { get; set; }
+        private Meta ShowMeta { get; set; }
+
 
         public SaveEditor(string jsonFile)
         {
@@ -46,6 +48,29 @@ namespace D_OS_Save_Editor
         public SaveEditor(Savegame savegame)
         {
             InitializeComponent();
+
+            ShowMeta = savegame.Meta;
+            // check number of game version and inform user
+            if (ShowMeta.GameVersion.Count > 1)
+            {
+                string formatedVersions = "";
+                foreach (string gameVersion in ShowMeta.GameVersion)
+                {
+                    formatedVersions += "\n  " + gameVersion;
+                }
+                MessageBox.Show("DOS EE Editor found " + ShowMeta.GameVersion.Count + " game versions for this savegame\nDOS EE Editor and this modified savegame may be unstable: keep play on latest version you have.\nGame Version:" + formatedVersions, "Too many game version", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+
+            if (ShowMeta.ModsName.Count > 1)
+            {
+                string formatedMods = "";
+                foreach (string modName in ShowMeta.ModsName)
+                {
+                    if (modName != "Shared")
+                        formatedMods += "\n  " + modName;
+                }
+                MessageBox.Show("DOS EE Editor found " + (ShowMeta.ModsName.Count - 1) + " mod" + ((ShowMeta.ModsName.Count - 1) > 1 ? "s" : "") + " for this savegame\nDOS EE Editor and this modified savegame may be unstable.\nThe savegame will be mostly corrupted if it's edited by DOS EE Editor\nMods name:" + formatedMods, "Mod" + (ShowMeta.ModsName.Count > 1 ? "s" : "") + " found", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
 
             Savegame = savegame;
             // make a copy of players
@@ -77,6 +102,7 @@ namespace D_OS_Save_Editor
             InventoryTab.Player = EditingPlayers[id];
             TraitsTab.Player = EditingPlayers[id];
             TalentTab.Player = EditingPlayers[id];
+            GameInfoTab.Meta = ShowMeta;
 
             if (EditingPlayers[id].Name == "Henchman")
             {
@@ -155,6 +181,7 @@ namespace D_OS_Save_Editor
         {
             Savegame = null;
             EditingPlayers = null;
+            ShowMeta = null;
         }
 
         private void DebugButton_OnClick(object sender, RoutedEventArgs e)

--- a/D-OS Save Editor/savegame/LsxParser.cs
+++ b/D-OS Save Editor/savegame/LsxParser.cs
@@ -293,6 +293,54 @@ namespace D_OS_Save_Editor
 
             return item;
         }
+
+        public static Meta ParseMeta(XmlDocument doc)
+        {
+            var metaData = doc.DocumentElement?.SelectSingleNode("./region [@id='MetaData']/node [@id='MetaData']/children/node [@id='MetaData']");
+            if (metaData == null)
+            {
+                throw new XmlException("Unable to find MeteData in meta savegame.");
+            }
+
+            var meta = new Meta
+            {
+                Level = metaData.SelectSingleNode("attribute [@id='Level']")?.Attributes[1].Value,
+                Seed = metaData.SelectSingleNode("attribute [@id='Seed']")?.Attributes[1].Value,
+                Difficulty = Int16.Parse(metaData.SelectSingleNode("attribute [@id='Difficulty']")?.Attributes[1].Value),
+                SaveGameType = Int16.Parse(metaData.SelectSingleNode("attribute [@id='SaveGameType']")?.Attributes[1].Value)
+            };
+
+            //Debug.WriteLine("TimeStamp: " + metaData.SelectSingleNode("attribute [@id='TimeStamp']")?.Attributes[1].Value);
+            //Debug.WriteLine("Size: " + metaData.SelectSingleNode("attribute [@id='Size']")?.Attributes[1].Value);
+
+
+            var saveTimeNode = metaData.SelectSingleNode("children/node [@id='SaveTime']");
+
+            meta.SaveTimeRead(
+                Int16.Parse(saveTimeNode.SelectSingleNode("attribute [@id='Year']")?.Attributes[1].Value),
+                saveTimeNode.SelectSingleNode("attribute [@id='Month']")?.Attributes[1].Value,
+                saveTimeNode.SelectSingleNode("attribute [@id='Day']")?.Attributes[1].Value,
+                saveTimeNode.SelectSingleNode("attribute [@id='Hours']")?.Attributes[1].Value,
+                saveTimeNode.SelectSingleNode("attribute [@id='Minutes']")?.Attributes[1].Value,
+                saveTimeNode.SelectSingleNode("attribute [@id='Seconds']")?.Attributes[1].Value,
+                Int16.Parse(saveTimeNode.SelectSingleNode("attribute [@id='Milliseconds']")?.Attributes[1].Value)
+                );
+            
+
+            var gameVersionChildrenNodes = metaData.SelectNodes("children/node [@id='GameVersions']/children/node [@id='GameVersion']");
+            foreach (XmlNode gameVersionNode in gameVersionChildrenNodes)
+            {
+                meta.GameVersion.Add(gameVersionNode.SelectSingleNode("attribute")?.Attributes[1].Value);
+            }
+
+            var modsChildrenNodes = metaData.SelectNodes("children/node [@id='ModuleSettings']/children/node [@id='Mods']/children/node [@id='ModuleShortDesc']");
+            foreach (XmlNode moduleModNode in modsChildrenNodes)
+            {
+                meta.ModsName.Add(moduleModNode.SelectSingleNode("attribute [@id='Name']")?.Attributes[1].Value);
+            }
+
+            return meta;
+        }
         #endregion
 
         #region write file

--- a/D-OS Save Editor/savegame/Meta.cs
+++ b/D-OS Save Editor/savegame/Meta.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace D_OS_Save_Editor
+{
+    public class Meta
+    {
+        public enum DifficultyEnum
+        {
+            Story = 0,
+            Classic,
+            Tactician,
+            Honour
+        }
+        public enum SaveGameTypeEnum
+        {
+            Manual = 0,
+            QuickSave,
+            AutoSave,
+            HonourSave
+        }
+        private string _level;
+        private int _difficulty;
+        private List<string> _gameVersion;
+        private int _saveGameType;
+        private string _seed;
+        private string _saveTime;
+        private List<string> _modsName;
+
+        //<node id="MetaData">
+
+        //<attribute id = "Level" value="Cyseal" type="22" />
+        /// <summary>
+        /// Game map/level
+        /// </summary>
+        public string Level { get => _level; set => _level = value; }
+        /// <summary>
+        /// Difficulty Game
+        /// </summary>
+        public int Difficulty { get => _difficulty; set => _difficulty = value; }
+        /// <summary>
+        /// Full game version
+        /// </summary>
+        public List<string> GameVersion { get => _gameVersion; set => _gameVersion = value; }
+        /// <summary>
+        /// Date of savegame created
+        /// </summary>
+        public string SaveTime { get => _saveTime; set => _saveTime = value; }
+        /// <summary>
+        /// List of Mod's Name load in game
+        /// </summary>
+        public List<string> ModsName { get => _modsName; set => _modsName = value; }
+        //<attribute id="SaveGameType" value="2" type="27" />
+        /// <summary>
+        /// The type of SaveGame
+        /// </summary>
+        public int SaveGameType { get => _saveGameType; set => _saveGameType = value; }
+        public string Seed { get => _seed; set => _seed = value; }
+
+        public Meta()
+        {
+            GameVersion = new List<string>();
+            ModsName = new List<string>();
+        }
+
+        public void SaveTimeRead(int year, string month, string day, string hours, string minutes, string secondes, int milliseconds)
+        {
+            SaveTime = Convert.ToString(1900 + year) + '/' + month.PadLeft(2, '0') + '/' + day.PadLeft(2, '0') + ' ' + hours.PadLeft(2, '0') + ':' + minutes.PadLeft(2, '0') + ':' + secondes.PadLeft(2, '0');
+        }
+    }
+}

--- a/D-OS Save Editor/savegame/Savegame.cs
+++ b/D-OS Save Editor/savegame/Savegame.cs
@@ -19,6 +19,7 @@ namespace D_OS_Save_Editor
         public string SavegameFullFile { get; set; }
         public string UnpackDirectory { get; }
         public Player[] Players { get; set; }
+        public Meta Meta { get; set; }
         public string[] AllSkills { get; set; }
         public Game GameVersion { get; }
 
@@ -39,12 +40,15 @@ namespace D_OS_Save_Editor
             await Task.Delay(1);
             // load xml
             var doc = new XmlDocument();
+            var metaDoc = new XmlDocument();
             doc.Load(UnpackDirectory + Path.DirectorySeparatorChar + "globals.lsx");
+            metaDoc.Load(UnpackDirectory + Path.DirectorySeparatorChar + "meta.lsx");
             // update progress
             progress.Report("Analysing savegame.");
             await Task.Delay(1);
             // parse xlml
             Players = LsxParser.ParsePlayer(doc);
+            Meta = LsxParser.ParseMeta(metaDoc);
             // update progress
             progress.Report("Loading data.");
             await Task.Delay(1);
@@ -94,6 +98,8 @@ namespace D_OS_Save_Editor
             // save package
             ResourceUtils.SaveResource(global, UnpackDirectory + Path.DirectorySeparatorChar + "globals.lsx",
                 ResourceFormat.LSX, outputVersion);
+            // uncompress and save meta.lsf
+            ResourceUtils.SaveResource(ResourceUtils.LoadResource(UnpackDirectory + Path.DirectorySeparatorChar + "meta.lsf"), UnpackDirectory + Path.DirectorySeparatorChar + "meta.lsx",ResourceFormat.LSX, outputVersion);
         }
 
         /// <summary>
@@ -116,6 +122,7 @@ namespace D_OS_Save_Editor
 
             // delete .lsx
             File.Delete(UnpackDirectory + Path.DirectorySeparatorChar + "globals.lsx");
+            File.Delete(UnpackDirectory + Path.DirectorySeparatorChar + "meta.lsx");
 
             // update progress
             progress.Report("Packing savegame.");


### PR DESCRIPTION
A new tab is created and showed about Game Info like :
- Game Difficulty
- Save Game Type
- Seed of game
- Map/Level refered in savegame
- Date of record
- Game Version(s)
- Mod Name(s)

And when the savegame is loaded, a warning appears to warn about multiple game version and presence of mods

This is an image that contains two screenshot melted
![sans-titre-1](https://user-images.githubusercontent.com/35181101/40274086-87451bf4-5bce-11e8-8138-8874b8d44710.jpg)

This is an archive with executable generated in Debug build 
[D-OS-Test.zip](https://github.com/tmxkn1/D-OS-Save-Editor/files/2019895/D-OS-Test.zip)

P.S. Maybe game info like game version can be added to error report after the D-OS version with mods info

PPS Need to check Warning Texts and Game Info Tab Text about grammar and orthography etc... Thanks ^^