### PR TITLE
D:OS EE: nested inventory, item save fixes, inventory UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ SortGenerationList/bin/
 SortGenerationList/obj/
 *.bak
 DeltaModifier.txt
+
+_patch_apply_pending.py
+_patch*.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes in this fork are documented here (upstream: [AnthonyZJiang/D-OS-Save-Editor](https://github.com/AnthonyZJiang/D-OS-Save-Editor)).
+
+## Post-fork improvements (master)
+
+### Session and save UX
+
+- **Dirty state:** Window title `*` and “Not saved to file” when there are in-memory changes not written to disk; close prompt; cleared on successful Save and Reset.
+- **Unapplied edits:** Character **Apply** and inventory **Apply changes** enable when pending edits exist; orange labels (“Unapplied edits”) with **Apply** before the label so the button does not jump; close warns if character or inventory edits are still unapplied.
+- **Tabs:** Stats, Abilities, Traits, Talents report pending edits so Apply state stays accurate.
+
+### Inventory
+
+- **Amount (stack count):** Centralized rules via `IsAmountEditable()`. Amount is editable for stackable-style items (potions, loot, skill books, arrows, etc.) and **not** for equipment-style rows (weapons, armor, furniture), quest items, keys, **Unique** rarity, or stats ids starting with `arm_` (armor), matching game behavior better than the old allow-list (potion/gold/grenade/scroll/food only).
+- **Gold:** `DataTable.GoldNames` extended (e.g. `larger_gold`) so gold is categorized and filtered correctly.
+- **Layout:** Inventory pending label aligned with character bar (Apply left, message right).
+
+### Build
+
+- **SortGenerationList** retargeted to **.NET Framework 4.6.2** so the solution builds with the same targeting pack as the main WPF app (`App.config` / `csproj` updated).
+
+### Other
+
+- **wishlist.md** — backlog and done reference for future work (nested containers, skills/story tabs, D:OS 2, etc.).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes in this fork are documented here (upstream: [AnthonyZJiang/D
 
 ### Inventory
 
+- **Saving item edits:** `WriteEditsToLsxAsync` loads a fresh `globals.lsx` document; inventory changes must target **that** tree. Previously, `ItemXmlNodes` from the initial parse pointed at the old DOM, so amount and other item edits did not persist to disk while character attributes (written via fresh XPath) still worked. Writes now replay the same BFS inventory walk on the loaded document. `WritePlayer` also uses a sequential loop instead of `Parallel.For` so multiple players do not concurrently mutate one `XmlDocument`.
 - **Amount (stack count):** Centralized rules via `IsAmountEditable()`. Amount is editable for stackable-style items (potions, loot, skill books, arrows, etc.) and **not** for equipment-style rows (weapons, armor, furniture), quest items, keys, **Unique** rarity, or stats ids starting with `arm_` (armor), matching game behavior better than the old allow-list (potion/gold/grenade/scroll/food only).
 - **Gold:** `DataTable.GoldNames` extended (e.g. `larger_gold`) so gold is categorized and filtered correctly.
 - **Layout:** Inventory pending label aligned with character bar (Apply left, message right).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes in this fork are documented here (upstream: [AnthonyZJiang/D-OS-Save-Editor](https://github.com/AnthonyZJiang/D-OS-Save-Editor)).
+All notable changes in **[phillenton/D-OS-Save-Editor](https://github.com/phillenton/D-OS-Save-Editor)** (this repository) are documented here. The original open-source project by Anthony Jiang is **[AnthonyZJiang/D-OS-Save-Editor](https://github.com/AnthonyZJiang/D-OS-Save-Editor)**.
 
 ## Post-fork improvements (master)
 

--- a/D-OS Save Editor/About.xaml
+++ b/D-OS Save Editor/About.xaml
@@ -19,7 +19,11 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="30,20,30,0" HorizontalAlignment="Left" VerticalAlignment="Center">
             <TextBlock Text="Open source at" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-            <TextBlock Margin="5,0,0,0"><Hyperlink NavigateUri="https://github.com/tmxkn1/D-OS-Save-Editor" RequestNavigate="Hyperlink_RequestNavigate">Github</Hyperlink></TextBlock>
+            <TextBlock Margin="5,0,0,0"><Hyperlink NavigateUri="https://github.com/phillenton/D-OS-Save-Editor" RequestNavigate="Hyperlink_RequestNavigate">Github</Hyperlink></TextBlock>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="30,5,30,0" HorizontalAlignment="Left" VerticalAlignment="Center">
+            <TextBlock Text="Original project:" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+            <TextBlock Margin="5,0,0,0"><Hyperlink NavigateUri="https://github.com/AnthonyZJiang/D-OS-Save-Editor" RequestNavigate="Hyperlink_RequestNavigate">AnthonyZJiang/D-OS-Save-Editor</Hyperlink></TextBlock>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="30,0,30,0" HorizontalAlignment="Left" VerticalAlignment="Center">
             <TextBlock Text="Use and discussions:" HorizontalAlignment="Left" VerticalAlignment="Center"/>

--- a/D-OS Save Editor/MainWindow.xaml.cs
+++ b/D-OS Save Editor/MainWindow.xaml.cs
@@ -69,7 +69,7 @@ namespace D_OS_Save_Editor
         private async Task CheckUpdate()
         {
             Debug.WriteLine("start");
-            const string urlAddress = "https://github.com/tmxkn1/D-OS-Save-Editor/blob/master/UpdateCheck";
+            const string urlAddress = "https://github.com/phillenton/D-OS-Save-Editor/blob/master/UpdateCheck";
             _updateLink = null;
             UpdatePanel.Visibility = Visibility.Collapsed;
 

--- a/D-OS Save Editor/SE/AbilitiesTab.xaml
+++ b/D-OS Save Editor/SE/AbilitiesTab.xaml
@@ -15,6 +15,7 @@
             <Setter Property="Width" Value="35"/>
             <EventSetter Event="LostFocus" Handler="TextBoxEventSetter_OnLostFocus"/>
             <EventSetter Event="PreviewTextInput" Handler="TextBoxEventSetter_OnPreviewTextInput"/>
+            <EventSetter Event="TextChanged" Handler="CharacterField_TextChanged"/>
         </Style>
         <Style TargetType="RowDefinition">
             <Setter Property="Height" Value="Auto"/>

--- a/D-OS Save Editor/SE/AbilitiesTab.xaml.cs
+++ b/D-OS Save Editor/SE/AbilitiesTab.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Controls.Primitives;
 
 namespace D_OS_Save_Editor
 {
@@ -11,6 +12,7 @@ namespace D_OS_Save_Editor
     public partial class AbilitiesTab
     {
         private Player _player;
+        private bool _suppressFieldEvents;
         private Brush DefaultTextBoxBorderBrush { get; }
 
         public Player Player
@@ -30,8 +32,53 @@ namespace D_OS_Save_Editor
             DefaultTextBoxBorderBrush = ManAtArmsTextBox.BorderBrush;
         }
 
+        public bool HasPendingEdits()
+        {
+            if (Player == null) return false;
+            if (ManAtArmsTextBox.Text != Player.Abilities[(int)DataTable.Abilities.ManAtArms].ToString()) return true;
+            if (ExpertMarksmanTextBox.Text != Player.Abilities[(int)DataTable.Abilities.ExpertMarksman].ToString()) return true;
+            if (ScoundrelTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Scoundrel].ToString()) return true;
+            if (SingleHandedTextBox.Text != Player.Abilities[(int)DataTable.Abilities.SingleHanded].ToString()) return true;
+            if (TwoHandedTextBox.Text != Player.Abilities[(int)DataTable.Abilities.TwoHanded].ToString()) return true;
+            if (BowTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Bow].ToString()) return true;
+            if (CrossbowTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Crossbow].ToString()) return true;
+            if (ShieldSpecialistTextBox.Text != Player.Abilities[(int)DataTable.Abilities.ShieldSpecialist].ToString()) return true;
+            if (ArmourSpecialistTextBox.Text != Player.Abilities[(int)DataTable.Abilities.ArmourSpecialist].ToString()) return true;
+            if (WitchcraftTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Witchcraft].ToString()) return true;
+            if (TelekinesisTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Telekinesis].ToString()) return true;
+            if (WillpowerTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Willpower].ToString()) return true;
+            if (PyrokineticTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Pyrokinetic].ToString()) return true;
+            if (HydrosophistTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Hydrosophist].ToString()) return true;
+            if (AerotheurgeTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Aerotheurge].ToString()) return true;
+            if (GeomancerTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Geomancer].ToString()) return true;
+            if (BlacksmithingTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Blacksmithing].ToString()) return true;
+            if (SneakingTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Sneaking].ToString()) return true;
+            if (PickpocketingTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Pickpocketing].ToString()) return true;
+            if (LockpickingTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Lockpicking].ToString()) return true;
+            if (LoremasterTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Loremaster].ToString()) return true;
+            if (CraftingTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Crafting].ToString()) return true;
+            if (BarteringTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Bartering].ToString()) return true;
+            if (CharismaTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Charisma].ToString()) return true;
+            if (LeadershipTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Leadership].ToString()) return true;
+            if (LuckyCharmTextBox.Text != Player.Abilities[(int)DataTable.Abilities.LuckyCharm].ToString()) return true;
+            if (BodyBuildingTextBox.Text != Player.Abilities[(int)DataTable.Abilities.BodyBuilding].ToString()) return true;
+            if (DualWieldingTextBox.Text != Player.Abilities[(int)DataTable.Abilities.DualWielding].ToString()) return true;
+            if (WandTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Wand].ToString()) return true;
+            if (TenebriumTextBox.Text != Player.Abilities[(int)DataTable.Abilities.Tenebrium].ToString()) return true;
+            return false;
+        }
+
+        private void CharacterField_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (_suppressFieldEvents) return;
+            if (Window.GetWindow(this) is SaveEditor editor)
+                editor.RefreshCharacterApplyPendingState();
+        }
         public void UpdateForm()
         {
+            _suppressFieldEvents = true;
+            try
+            {
             ManAtArmsTextBox.Text = Player.Abilities[(int)DataTable.Abilities.ManAtArms].ToString();
             ExpertMarksmanTextBox.Text = Player.Abilities[(int)DataTable.Abilities.ExpertMarksman].ToString();
             ScoundrelTextBox.Text = Player.Abilities[(int)DataTable.Abilities.Scoundrel].ToString();
@@ -62,6 +109,11 @@ namespace D_OS_Save_Editor
             DualWieldingTextBox.Text = Player.Abilities[(int)DataTable.Abilities.DualWielding].ToString();
             WandTextBox.Text = Player.Abilities[(int)DataTable.Abilities.Wand].ToString();
             TenebriumTextBox.Text = Player.Abilities[(int)DataTable.Abilities.Tenebrium].ToString();
+            }
+            finally
+            {
+                _suppressFieldEvents = false;
+            }
         }
 
         public void SaveEdits()

--- a/D-OS Save Editor/SE/InventoryTab.xaml
+++ b/D-OS Save Editor/SE/InventoryTab.xaml
@@ -15,6 +15,7 @@
             <Setter Property="HorizontalAlignment" Value="Left"></Setter>
             <EventSetter Event="LostFocus" Handler="TextBoxEventSetter_OnLostFocus"/>
             <EventSetter Event="PreviewTextInput" Handler="TextBoxEventSetter_OnPreviewTextInput"/>
+            <EventSetter Event="TextChanged" Handler="InventoryDetailField_Changed"/>
         </Style>
         <Style TargetType="RowDefinition">
             <Setter Property="Height" Value="Auto"/>
@@ -99,7 +100,7 @@
                     <TextBlock Text="Durability counter:" Grid.Row="2" Grid.Column="2" Margin="30,0,0,0"/>
                     <TextBlock Text="Repair durability penalty:" Grid.Row="3" Grid.Column="2" Margin="30,0,0,0"/>
                     <TextBox x:Name="AmountTextBox" Grid.Column="1" Margin="20,5,0,5" Width="90"/>
-                    <ComboBox x:Name="RarityComboBox" Grid.Column="1" Grid.Row="1" Width="90" Height="22" Margin="20,0,0,0"/>
+                    <ComboBox x:Name="RarityComboBox" SelectionChanged="RarityComboBox_OnSelectionChanged" Grid.Column="1" Grid.Row="1" Width="90" Height="22" Margin="20,0,0,0"/>
                     <TextBox x:Name="LockLevelTextBox" Grid.Row="2" Grid.Column="1"/>
                     <TextBox x:Name="LevelTextBox" Grid.Row="3" Grid.Column="1"/>
                     <StackPanel Grid.Row="0" Grid.Column="3" Orientation="Horizontal">
@@ -143,6 +144,13 @@
                 </Grid>
             </GroupBox>
         </WrapPanel>
-        <Button Grid.Column="1" Grid.Row="3" HorizontalAlignment="Right" Content="Apply changes" Padding="10,2" VerticalAlignment="Bottom" Margin="10" Click="ApplyChangesButton_OnClick"/>
+        <Grid Grid.Column="1" Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="ApplyChangesButton" Grid.Column="0" Content="Apply changes" Padding="10,2" VerticalAlignment="Center" Margin="10,0,8,0" Click="ApplyChangesButton_OnClick" IsEnabled="False"/>
+            <TextBlock x:Name="InventoryApplyPendingLabel" Grid.Column="1" Text="Unapplied edits" Foreground="#CC6600" FontWeight="SemiBold" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,0,10,0" Visibility="Collapsed"/>
+        </Grid>
     </Grid>
 </UserControl>

--- a/D-OS Save Editor/SE/InventoryTab.xaml
+++ b/D-OS Save Editor/SE/InventoryTab.xaml
@@ -46,7 +46,8 @@
             <TextBox Grid.Column="1" x:Name="SearchTextBox" Uid="SearchText" Margin="10,0,20,0" VerticalAlignment="Top" HorizontalAlignment="Stretch" Width="Auto" TextChanged="SearchTextBox_OnTextChanged"/>
             <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Use space to separate" FontSize="10" FontStyle="Italic"/>
         </Grid>
-        <ListBox x:Name="ItemsListBox" Grid.Row="1" Grid.RowSpan="3" HorizontalAlignment="Left" MinHeight="430" Height="Auto" Margin="10,0,20,10" VerticalAlignment="Top" Width="239" SelectionChanged="ItemsListBox_OnSelectionChanged"/>
+        <TreeView x:Name="ItemsTreeView" Grid.Row="1" Grid.RowSpan="3" HorizontalAlignment="Left" MinHeight="430" Height="Auto" Margin="10,0,20,10" VerticalAlignment="Top" Width="280"
+                  SelectedItemChanged="ItemsTreeView_OnSelectedItemChanged"/>
         <StackPanel Orientation="Horizontal" Grid.Column="1" Margin="0,0,0,10">
             <Button Content="Check all" Margin="0,0,20,0" Padding="5,2" Width="80" Click="CheckAllButton_OnClick" VerticalAlignment="Top"/>
             <Button Content="Uncheck all" Padding="5,2" Width="80" Click="UncheckAllButtonBase_OnClick" VerticalAlignment="Top"/>
@@ -65,6 +66,7 @@
             <CheckBox x:Name="ShowScrollCheckBox" Content="Scroll" Tag="{x:Static local:ItemSortType.Scroll}"/>
             <CheckBox x:Name="ShowPotionCheckBox" Content="Potion" Tag="{x:Static local:ItemSortType.Potion}"/>
             <CheckBox x:Name="ShowFurnitureCheckBox" Content="Furniture" Tag="{x:Static local:ItemSortType.Furniture}"/>
+            <CheckBox x:Name="ShowContainerCheckBox" Content="Containers" Tag="{x:Static local:ItemSortType.Container}"/>
             <CheckBox x:Name="ShowSkillbookCheckBox" Content="Skill book" Tag="{x:Static local:ItemSortType.Skillbook}"/>
             <CheckBox x:Name="ShowGrenadeCheckBox" Content="Grenade" Tag="{x:Static local:ItemSortType.Granade}"/>
             <CheckBox x:Name="ShowFoodCheckBox" Content="Food" Tag="{x:Static local:ItemSortType.Food}"/>
@@ -80,41 +82,44 @@
             <GroupBox Header="Stats" x:Name="StatsGroupBox">
                 <Grid>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition/>
                         <RowDefinition/>
                         <RowDefinition/>
                         <RowDefinition/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto" MinWidth="88"/>
+                        <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Text="Amount:"/>
-                    <TextBlock Text="Rarity:" Grid.Row="1"/>
-                    <TextBlock Text="Lock level:" Grid.Row="2"/>
-                    <TextBlock Text="Required level:" Grid.Row="3"/>
-                    <TextBlock Text="HP:" Grid.Row="0" Grid.Column="2" Margin="30,0,0,0"/>
-                    <TextBlock Text="Durability:" Grid.Row="1" Grid.Column="2" Margin="30,0,0,0"/>
-                    <TextBlock Text="Durability counter:" Grid.Row="2" Grid.Column="2" Margin="30,0,0,0"/>
-                    <TextBlock Text="Repair durability penalty:" Grid.Row="3" Grid.Column="2" Margin="30,0,0,0"/>
-                    <TextBox x:Name="AmountTextBox" Grid.Column="1" Margin="20,5,0,5" Width="90"/>
-                    <ComboBox x:Name="RarityComboBox" SelectionChanged="RarityComboBox_OnSelectionChanged" Grid.Column="1" Grid.Row="1" Width="90" Height="22" Margin="20,0,0,0"/>
-                    <TextBox x:Name="LockLevelTextBox" Grid.Row="2" Grid.Column="1"/>
-                    <TextBox x:Name="LevelTextBox" Grid.Row="3" Grid.Column="1"/>
-                    <StackPanel Grid.Row="0" Grid.Column="3" Orientation="Horizontal">
+                    <TextBlock x:Name="EquipmentSlotLabel" Text="Equip slot (0–14):" VerticalAlignment="Center" Visibility="Collapsed"/>
+                    <TextBlock x:Name="EquipmentSlotText" Grid.Column="1" Margin="12,2,0,2" VerticalAlignment="Center" Visibility="Collapsed" FontWeight="SemiBold"/>
+                    <TextBlock Text="Amount:" Grid.Row="1"/>
+                    <TextBlock Text="Rarity:" Grid.Row="2"/>
+                    <TextBlock Text="Lock level:" Grid.Row="3"/>
+                    <TextBlock Text="Required level:" Grid.Row="4"/>
+                    <TextBlock Text="HP:" Grid.Row="1" Grid.Column="2" Margin="30,0,0,0"/>
+                    <TextBlock Text="Durability:" Grid.Row="2" Grid.Column="2" Margin="30,0,0,0"/>
+                    <TextBlock Text="Durability counter:" Grid.Row="3" Grid.Column="2" Margin="30,0,0,0"/>
+                    <TextBlock Text="Repair durability penalty:" Grid.Row="4" Grid.Column="2" Margin="30,0,0,0"/>
+                    <TextBox x:Name="AmountTextBox" Grid.Row="1" Grid.Column="1" Margin="20,5,0,5" Width="90"/>
+                    <ComboBox x:Name="RarityComboBox" SelectionChanged="RarityComboBox_OnSelectionChanged" Grid.Column="1" Grid.Row="2" Width="90" Height="22" Margin="20,0,0,0"/>
+                    <TextBox x:Name="LockLevelTextBox" Grid.Row="3" Grid.Column="1"/>
+                    <TextBox x:Name="LevelTextBox" Grid.Row="4" Grid.Column="1"/>
+                    <StackPanel Grid.Row="1" Grid.Column="3" Orientation="Horizontal">
                         <TextBox x:Name="VitalityTextBox" Margin="20,5,5,5" Width="35"/>
                         <TextBlock Text="/"/>
                         <TextBox x:Name="MaxVitalityPatchCheckTextBox" Margin="5,5,0,5" Width="35"/>
                     </StackPanel>
-                    <StackPanel Grid.Row="1" Grid.Column="3" Orientation="Horizontal">
+                    <StackPanel Grid.Row="2" Grid.Column="3" Orientation="Horizontal">
                         <TextBox x:Name="DurabilityTextBox" Margin="20,5,5,5" Width="35"/>
                         <TextBlock Text="/"/>
                         <TextBox x:Name="MaxDurabilityPatchCheckTextBox" Margin="5,5,0,5" Width="35"/>
                     </StackPanel>
-                    <TextBox x:Name="DurabilityCounterTextBox" Grid.Row="2" Grid.Column="3"/>
-                    <TextBox x:Name="RepairDurabilityPenaltyTextBox" Grid.Row="3" Grid.Column="3"/>
+                    <TextBox x:Name="DurabilityCounterTextBox" Grid.Row="3" Grid.Column="3"/>
+                    <TextBox x:Name="RepairDurabilityPenaltyTextBox" Grid.Row="4" Grid.Column="3"/>
                 </Grid>
             </GroupBox>
             <GroupBox Header="Modifiers" Width="{Binding Width, ElementName=StatsGroupBox, Mode=OneWay}">

--- a/D-OS Save Editor/SE/InventoryTab.xaml.cs
+++ b/D-OS Save Editor/SE/InventoryTab.xaml.cs
@@ -17,6 +17,7 @@ namespace D_OS_Save_Editor
     public partial class InventoryTab
     {
         private Player _player;
+        private bool _suppressInventoryDetailEvents;
 
         private Brush DefaultTextBoxBorderBrush { get; }
         private Brush[] _itemRarityColor =
@@ -39,6 +40,63 @@ namespace D_OS_Save_Editor
             DefaultTextBoxBorderBrush = AmountTextBox.BorderBrush;
 
             RarityComboBox.ItemsSource = Enum.GetValues(typeof(Item.ItemRarityType)).Cast<Item.ItemRarityType>();
+        }
+
+        public bool HasPendingItemDetailEdits()
+        {
+            if (ItemsListBox.SelectedIndex < 0) return false;
+            var item = Player.Items[ItemsListBox.SelectedIndex];
+            var allowed = item.GetAllowedChangeType();
+
+            if (allowed.Contains(nameof(item.Amount)) && AmountTextBox.Text != item.Amount) return true;
+            if (allowed.Contains(nameof(item.LockLevel)) && LockLevelTextBox.Text != item.LockLevel) return true;
+            if (allowed.Contains(nameof(item.Vitality)) &&
+                (VitalityTextBox.Text != item.Vitality || MaxVitalityPatchCheckTextBox.Text != item.MaxVitalityPatchCheck))
+                return true;
+            if (allowed.Contains(nameof(item.ItemRarity)) && RarityComboBox.SelectedIndex >= 0 &&
+                (int)item.ItemRarity != RarityComboBox.SelectedIndex) return true;
+            if (allowed.Contains(nameof(item.Stats)) && item.Stats != null)
+            {
+                if (DurabilityTextBox.Text != (item.Stats.Durability ?? "")) return true;
+                if (DurabilityCounterTextBox.Text != (item.Stats.DurabilityCounter ?? "")) return true;
+                if (RepairDurabilityPenaltyTextBox.Text != (item.Stats.RepairDurabilityPenalty ?? "")) return true;
+                if (LevelTextBox.Text != (item.Stats.Level ?? "")) return true;
+            }
+            if (allowed.Contains(nameof(item.Generation)))
+            {
+                var uiBoosts = BoostsListBox.Items.Cast<string>().ToList();
+                var gen = item.Generation;
+                if (gen == null || gen.Boosts == null)
+                {
+                    if (uiBoosts.Count > 0) return true;
+                }
+                else if (!uiBoosts.SequenceEqual(gen.Boosts)) return true;
+            }
+            return false;
+        }
+
+        public void RefreshInventoryApplyUi()
+        {
+            var pending = ItemsListBox.SelectedIndex >= 0 && HasPendingItemDetailEdits();
+            ApplyChangesButton.IsEnabled = pending;
+            if (InventoryApplyPendingLabel != null)
+                InventoryApplyPendingLabel.Visibility = pending ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void InventoryDetailField_Changed(object sender, TextChangedEventArgs e)
+        {
+            if (_suppressInventoryDetailEvents) return;
+            if (sender is TextBox tb && tb.Uid == "SearchText") return;
+            if (Window.GetWindow(this) is SaveEditor se)
+            {
+                RefreshInventoryApplyUi();
+            }
+        }
+
+        private void RarityComboBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressInventoryDetailEvents) return;
+            RefreshInventoryApplyUi();
         }
 
         public void UpdateForm()
@@ -65,6 +123,7 @@ namespace D_OS_Save_Editor
                 if (i is TextBox t)
                     t.Text = "";
             }
+            RefreshInventoryApplyUi();
         }
 
         private void TextBoxEventSetter_OnLostFocus(object sender, RoutedEventArgs e)
@@ -88,6 +147,9 @@ namespace D_OS_Save_Editor
 
         private void ItemsListBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            _suppressInventoryDetailEvents = true;
+            try
+            {
             // clear list boxes
             BoostsListBox.Items.Clear();
             PermBoostsListBox.Items.Clear();
@@ -171,6 +233,12 @@ namespace D_OS_Save_Editor
                     PermBoostsListBox.Items.Add($"{m.Key} - {m.Value}");
                 }
             }
+            }
+            finally
+            {
+                _suppressInventoryDetailEvents = false;
+            }
+            RefreshInventoryApplyUi();
         }
         
         private void CheckboxEventSetter_OnClick(object sender, RoutedEventArgs e)
@@ -236,8 +304,23 @@ namespace D_OS_Save_Editor
 
         private void ApplyChangesButton_OnClick(object sender, RoutedEventArgs e)
         {
-            if (ItemsListBox.SelectedIndex < 0)
+            if (!TryApplySelectedItemChanges(sender as Button))
                 return;
+        }
+
+        /// <summary>
+        /// Used by main Save to commit inventory UI before writing globals.lsx.
+        /// </summary>
+        public bool TryApplyPendingInventoryForMainSave()
+        {
+            if (!HasPendingItemDetailEdits()) return true;
+            return TryApplySelectedItemChanges(null);
+        }
+
+        private bool TryApplySelectedItemChanges(Button toolTipButton)
+        {
+            if (ItemsListBox.SelectedIndex < 0)
+                return false;
 
             try
             {
@@ -283,7 +366,7 @@ namespace D_OS_Save_Editor
                                 var er = new ErrorReporting("It is not possible to add modifier to this item yet. No changes have been applied.", $"Item.Stats Null. Cannot add item modifiers.\n\nItem XML:\n{sw}", null);
                                 er.ShowDialog();
                             }
-                            return;
+                            return false;
                         }
                         item.Generation = new Item.GenerationNode(item.StatsName, "0");
                     }
@@ -313,27 +396,38 @@ namespace D_OS_Save_Editor
                 ((ListBoxItem) ItemsListBox.Items[ItemsListBox.SelectedIndex]).Foreground =
                     _itemRarityColor[(int) item.ItemRarity];
 
-                var tooltip = new ToolTip { Content = "Changes have been applied!" };
-                ((Button) sender).ToolTip = tooltip;
-                tooltip.Opened += async delegate (object o, RoutedEventArgs args)
+                if (toolTipButton != null)
                 {
-                    var s = o as ToolTip;
-                    await Task.Delay(1000);
-                    s.IsOpen = false;
-                    await Task.Delay(1000);
-                    ((Button)sender).ClearValue(ToolTipProperty);
-                };
-                tooltip.IsOpen = true;
+                    var tooltip = new ToolTip { Content = "Changes have been applied!" };
+                    toolTipButton.ToolTip = tooltip;
+                    tooltip.Opened += async delegate (object o, RoutedEventArgs args)
+                    {
+                        var s = o as ToolTip;
+                        await Task.Delay(1000);
+                        s.IsOpen = false;
+                        await Task.Delay(1000);
+                        toolTipButton.ClearValue(ToolTipProperty);
+                    };
+                    tooltip.IsOpen = true;
+                }
+
+                RefreshInventoryApplyUi();
+
+                if (Window.GetWindow(this) is SaveEditor se)
+                    se.MarkUnsavedSessionChanges();
+                return true;
             }
             catch (XmlValidationException ex)
             {
                 MessageBox.Show($"Invalid value entered: {ex.Name}: {ex.Value}. No change has been applied.\n\n{ex.Message}", "Error",
                     MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
             }
             catch (Exception ex)
             {
                 MessageBox.Show($"Internal error. No change has been applied.\n\n{ex.Message}", "Error",
                     MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
             }
         }
 
@@ -368,13 +462,17 @@ namespace D_OS_Save_Editor
                     var dlg=new AddBoostDialog(predictedKeyword);
                     dlg.ShowDialog();
                     if (dlg.DialogResult == true)
+                    {
                         BoostsListBox.Items.Add(dlg.BoostText);
+                        RefreshInventoryApplyUi();
+                    }
                     break;
                 case "Copy text":
                     Clipboard.SetText((string)BoostsListBox.SelectedValue);
                     break;
                 case "Delete":
                     BoostsListBox.Items.RemoveAt(BoostsListBox.SelectedIndex);
+                    RefreshInventoryApplyUi();
                     break;
             }
         }

--- a/D-OS Save Editor/SE/InventoryTab.xaml.cs
+++ b/D-OS Save Editor/SE/InventoryTab.xaml.cs
@@ -19,6 +19,9 @@ namespace D_OS_Save_Editor
         private Player _player;
         private bool _suppressInventoryDetailEvents;
 
+        /// <summary>Index into <see cref="Player.Items"/> for the selected tree row, or -1.</summary>
+        private int _selectedItemIndex = -1;
+
         private Brush DefaultTextBoxBorderBrush { get; }
         private Brush[] _itemRarityColor =
             {Brushes.Black, Brushes.ForestGreen, Brushes.DodgerBlue, Brushes.BlueViolet, Brushes.DeepPink, Brushes.Gold, Brushes.DimGray};
@@ -44,8 +47,8 @@ namespace D_OS_Save_Editor
 
         public bool HasPendingItemDetailEdits()
         {
-            if (ItemsListBox.SelectedIndex < 0) return false;
-            var item = Player.Items[ItemsListBox.SelectedIndex];
+            if (_selectedItemIndex < 0 || _selectedItemIndex >= Player.Items.Length) return false;
+            var item = Player.Items[_selectedItemIndex];
             var allowed = item.GetAllowedChangeType();
 
             if (allowed.Contains(nameof(item.Amount)) && AmountTextBox.Text != item.Amount) return true;
@@ -77,7 +80,7 @@ namespace D_OS_Save_Editor
 
         public void RefreshInventoryApplyUi()
         {
-            var pending = ItemsListBox.SelectedIndex >= 0 && HasPendingItemDetailEdits();
+            var pending = _selectedItemIndex >= 0 && HasPendingItemDetailEdits();
             ApplyChangesButton.IsEnabled = pending;
             if (InventoryApplyPendingLabel != null)
                 InventoryApplyPendingLabel.Visibility = pending ? Visibility.Visible : Visibility.Collapsed;
@@ -101,24 +104,37 @@ namespace D_OS_Save_Editor
 
         public void UpdateForm()
         {
-            ItemsListBox.Items.Clear();
-            foreach (var i in Player.Items)
-                ItemsListBox.Items.Add(new ListBoxItem
-                {
-                    Content = i.StatsName,
-                    Tag = i.ItemSort,
-                    Foreground = _itemRarityColor[(int)i.ItemRarity]
-                });
+            _selectedItemIndex = -1;
+            ItemsTreeView.Items.Clear();
+            EquipmentSlotText.Text = "";
+            EquipmentSlotLabel.Visibility = Visibility.Collapsed;
+            EquipmentSlotText.Visibility = Visibility.Collapsed;
 
-            // check filter
+            if (Player?.Items == null || Player.Items.Length == 0)
+            {
+                foreach (var i in ShowWrapPanel.Children)
+                {
+                    if (i is CheckBox)
+                        CheckboxEventSetter_OnClick(i, new RoutedEventArgs());
+                }
+                foreach (var i in ValueWrapPanel.Children)
+                {
+                    if (i is TextBox t)
+                        t.Text = "";
+                }
+                RefreshInventoryApplyUi();
+                return;
+            }
+
+            RebuildItemTree();
+
             foreach (var i in ShowWrapPanel.Children)
             {
                 if (i is CheckBox)
                     CheckboxEventSetter_OnClick(i, new RoutedEventArgs());
             }
 
-            // clear all text boxes
-            foreach(var i in ValueWrapPanel.Children)
+            foreach (var i in ValueWrapPanel.Children)
             {
                 if (i is TextBox t)
                     t.Text = "";
@@ -126,113 +142,156 @@ namespace D_OS_Save_Editor
             RefreshInventoryApplyUi();
         }
 
-        private void TextBoxEventSetter_OnLostFocus(object sender, RoutedEventArgs e)
+        private void RebuildItemTree()
         {
-            if (!(sender is TextBox s)) return;
-            if (s.Uid == "SearchText") return;
+            ItemsTreeView.Items.Clear();
+            var byParent = Player.Items
+                .GroupBy(it => it.Parent)
+                .ToDictionary(g => g.Key, g => g.OrderBy(x => int.Parse(x.Slot)).ToList());
 
-            var text = s.Text;
-            var valid = int.TryParse(text, out int _);
-            s.BorderBrush = !valid ? Brushes.Red : DefaultTextBoxBorderBrush;
+            if (!byParent.TryGetValue(Player.InventoryId, out var roots))
+                return;
+
+            foreach (var root in roots)
+                ItemsTreeView.Items.Add(BuildTreeItem(root, byParent));
         }
 
-        private void TextBoxEventSetter_OnPreviewTextInput(object sender, TextCompositionEventArgs e)
+        private TreeViewItem BuildTreeItem(Item item, Dictionary<string, List<Item>> byParent)
         {
-            if (!(sender is TextBox s)) return;
-            if (s.Uid == "SearchText") return;
+            var header = FormatItemTreeLabel(item);
+            var tvi = new TreeViewItem
+            {
+                Header = header,
+                Tag = item,
+                IsExpanded = false,
+                Foreground = _itemRarityColor[(int)item.ItemRarity]
+            };
 
-            var text = s.Text.Insert(s.SelectionStart, e.Text);
-            e.Handled = !int.TryParse(text, out int _);
+            var nested = item.NestedInventoryId;
+            if (!string.IsNullOrEmpty(nested) && nested != "0" && byParent.TryGetValue(nested, out var kids))
+            {
+                foreach (var ch in kids)
+                    tvi.Items.Add(BuildTreeItem(ch, byParent));
+            }
+
+            return tvi;
         }
 
-        private void ItemsListBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        private string FormatItemTreeLabel(Item item)
+        {
+            var equipped = item.IsEquippedPaperDoll(Player?.InventoryId) ? "\U0001F464 " : "";
+            if (!string.IsNullOrWhiteSpace(item.DisplayName))
+                return $"{equipped}{item.DisplayName}  ({item.StatsName})";
+            return $"{equipped}{item.StatsName}";
+        }
+
+        private static string GetItemSearchText(Item item)
+        {
+            var s = (item.DisplayName ?? "") + " " + (item.StatsName ?? "");
+            return s.Trim().ToLowerInvariant();
+        }
+
+        private void ItemsTreeView_OnSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (e.NewValue is TreeViewItem tvi && tvi.Tag is Item item)
+            {
+                _selectedItemIndex = item.ItemXmlNodeIdx;
+                // Tag can be stale after Apply (clone replaces Player.Items[i]); always use canonical row.
+                if (Player?.Items != null && _selectedItemIndex >= 0 && _selectedItemIndex < Player.Items.Length)
+                    PopulateItemDetail(Player.Items[_selectedItemIndex]);
+                else
+                    PopulateItemDetail(item);
+            }
+            else
+            {
+                _selectedItemIndex = -1;
+            }
+        }
+
+        private void PopulateItemDetail(Item item)
         {
             _suppressInventoryDetailEvents = true;
             try
             {
-            // clear list boxes
-            BoostsListBox.Items.Clear();
-            PermBoostsListBox.Items.Clear();
+                BoostsListBox.Items.Clear();
+                PermBoostsListBox.Items.Clear();
 
-            var lb = sender as ListBox;
-            if (lb.SelectedIndex < 0)
-                return;
-            var item = Player.Items[lb.SelectedIndex];
+                if (item.IsEquippedPaperDoll(Player?.InventoryId))
+                {
+                    EquipmentSlotLabel.Visibility = Visibility.Visible;
+                    EquipmentSlotText.Visibility = Visibility.Visible;
+                    EquipmentSlotText.Text = item.Slot;
+                }
+                else
+                {
+                    EquipmentSlotLabel.Visibility = Visibility.Collapsed;
+                    EquipmentSlotText.Visibility = Visibility.Collapsed;
+                    EquipmentSlotText.Text = "";
+                }
 
+                var allowedChanges = item.GetAllowedChangeType();
 
-            var allowedChanges = item.GetAllowedChangeType();
-            #region enable disable controls
+                if (allowedChanges.Contains(nameof(item.Vitality)))
+                {
+                    VitalityTextBox.IsEnabled = true;
+                    MaxVitalityPatchCheckTextBox.IsEnabled = true;
+                }
+                else
+                {
+                    VitalityTextBox.IsEnabled = false;
+                    MaxVitalityPatchCheckTextBox.IsEnabled = false;
+                }
 
-            if (allowedChanges.Contains(nameof(item.Vitality)))
-            {
-                VitalityTextBox.IsEnabled = true;
-                MaxVitalityPatchCheckTextBox.IsEnabled = true;
-            }
-            else
-            {
-                VitalityTextBox.IsEnabled = false;
-                MaxVitalityPatchCheckTextBox.IsEnabled = false;
-            }
+                RarityComboBox.IsEnabled = allowedChanges.Contains(nameof(item.ItemRarity));
+                AmountTextBox.IsEnabled = allowedChanges.Contains(nameof(item.Amount));
+                LockLevelTextBox.IsEnabled = allowedChanges.Contains(nameof(item.LockLevel));
+                BoostsListBox.IsEnabled = allowedChanges.Contains(nameof(item.Generation));
 
-            RarityComboBox.IsEnabled = allowedChanges.Contains(nameof(item.ItemRarity));
-            AmountTextBox.IsEnabled = allowedChanges.Contains(nameof(item.Amount));
-            LockLevelTextBox.IsEnabled = allowedChanges.Contains(nameof(item.LockLevel));
-            BoostsListBox.IsEnabled = allowedChanges.Contains(nameof(item.Generation));
-
-            if (allowedChanges.Contains(nameof(item.Stats)))
-            {
-                DurabilityTextBox.IsEnabled = true;
-                MaxDurabilityPatchCheckTextBox.IsEnabled = false;
-                DurabilityCounterTextBox.IsEnabled = true;
-                RepairDurabilityPenaltyTextBox.IsEnabled = true;
-                LevelTextBox.IsEnabled = true;
-                PermBoostsListBox.IsEnabled = true;
-            }
-            else
-            {
-                DurabilityTextBox.IsEnabled = false;
-                MaxDurabilityPatchCheckTextBox.IsEnabled = false;
-                DurabilityCounterTextBox.IsEnabled = false;
-                RepairDurabilityPenaltyTextBox.IsEnabled = false;
-                LevelTextBox.IsEnabled = false;
-                PermBoostsListBox.IsEnabled = false;
-            }
-            #endregion
+                if (allowedChanges.Contains(nameof(item.Stats)))
+                {
+                    DurabilityTextBox.IsEnabled = true;
+                    MaxDurabilityPatchCheckTextBox.IsEnabled = false;
+                    DurabilityCounterTextBox.IsEnabled = true;
+                    RepairDurabilityPenaltyTextBox.IsEnabled = true;
+                    LevelTextBox.IsEnabled = true;
+                    PermBoostsListBox.IsEnabled = true;
+                }
+                else
+                {
+                    DurabilityTextBox.IsEnabled = false;
+                    MaxDurabilityPatchCheckTextBox.IsEnabled = false;
+                    DurabilityCounterTextBox.IsEnabled = false;
+                    RepairDurabilityPenaltyTextBox.IsEnabled = false;
+                    LevelTextBox.IsEnabled = false;
+                    PermBoostsListBox.IsEnabled = false;
+                }
 
 #if DEBUG && LOG_ITEMXML
-            Console.WriteLine(item.Xml);
+                Console.WriteLine(item.Xml);
 #endif
-            // textbox contents
-            AmountTextBox.Text = item.Amount;
-            LockLevelTextBox.Text = item.LockLevel;
-            VitalityTextBox.Text = item.Vitality;
-            MaxVitalityPatchCheckTextBox.Text = item.MaxVitalityPatchCheck;
-            DurabilityTextBox.Text = item.Stats?.Durability ?? "";
-            DurabilityCounterTextBox.Text = item.Stats?.DurabilityCounter ?? "";
-            MaxDurabilityPatchCheckTextBox.Text = item.MaxDurabilityPatchCheck;
-            RepairDurabilityPenaltyTextBox.Text = item.Stats?.RepairDurabilityPenalty ?? "";
-            LevelTextBox.Text = item.Stats?.Level ?? "";
+                AmountTextBox.Text = item.Amount;
+                LockLevelTextBox.Text = item.LockLevel;
+                VitalityTextBox.Text = item.Vitality;
+                MaxVitalityPatchCheckTextBox.Text = item.MaxVitalityPatchCheck;
+                DurabilityTextBox.Text = item.Stats?.Durability ?? "";
+                DurabilityCounterTextBox.Text = item.Stats?.DurabilityCounter ?? "";
+                MaxDurabilityPatchCheckTextBox.Text = item.MaxDurabilityPatchCheck;
+                RepairDurabilityPenaltyTextBox.Text = item.Stats?.RepairDurabilityPenalty ?? "";
+                LevelTextBox.Text = item.Stats?.Level ?? "";
 
-            // combobox
-            RarityComboBox.SelectedIndex = (int) item.ItemRarity;
+                RarityComboBox.SelectedIndex = (int)item.ItemRarity;
 
-            // generation
-            if (item.Generation != null)
-            {
-                foreach (var m in item.Generation.Boosts)
+                if (item.Generation != null)
                 {
-                    BoostsListBox.Items.Add(m);
+                    foreach (var m in item.Generation.Boosts)
+                        BoostsListBox.Items.Add(m);
                 }
-            }
 
-            // stats
-            if (item.Stats != null)
-            {
-                foreach (var m in item.Stats.PermanentBoost)
+                if (item.Stats != null)
                 {
-                    PermBoostsListBox.Items.Add($"{m.Key} - {m.Value}");
+                    foreach (var m in item.Stats.PermanentBoost)
+                        PermBoostsListBox.Items.Add($"{m.Key} - {m.Value}");
                 }
-            }
             }
             finally
             {
@@ -240,46 +299,61 @@ namespace D_OS_Save_Editor
             }
             RefreshInventoryApplyUi();
         }
-        
+
         private void CheckboxEventSetter_OnClick(object sender, RoutedEventArgs e)
         {
-            var ckb = sender as CheckBox;
-            if (!(ckb?.Tag is ItemSortType))
-                return;
-
-            if ((ItemSortType) ckb.Tag == ItemSortType.Other)
-            {
-                foreach (ListBoxItem i in ItemsListBox.Items)
-                {
-                    if ((ItemSortType) i.Tag == ItemSortType.Item || (ItemSortType) i.Tag == ItemSortType.Unique ||
-                        (ItemSortType) i.Tag == ItemSortType.Other)
-                        i.Visibility = ckb.IsChecked == true && !IsFilteredOutByText(i.Content as string) ? Visibility.Visible:Visibility.Collapsed;
-                }
-            }
-            else
-            {
-                foreach (ListBoxItem i in ItemsListBox.Items)
-                {
-                    if ((ItemSortType)i.Tag == (ItemSortType)ckb.Tag)
-                        i.Visibility = ckb.IsChecked == true && !IsFilteredOutByText(i.Content as string) ? Visibility.Visible : Visibility.Collapsed;
-                }
-            }
+            ApplyTreeFilter();
         }
 
-        private bool IsFilteredOutByText(string itemName)
+        private void ApplyTreeFilter()
         {
-            var isFilteredOut = false;
-            itemName = itemName.ToLower();
-            var searchTerms = SearchTextBox.Text.ToLower().Split(' ');
-            foreach (var s in searchTerms)
-            {
-                if (itemName.Contains(s)) continue;
+            foreach (TreeViewItem root in ItemsTreeView.Items)
+                ApplyTreeFilterRecursive(root);
+        }
 
-                isFilteredOut = true;
-                break;
+        private bool ApplyTreeFilterRecursive(TreeViewItem node)
+        {
+            var item = node.Tag as Item;
+            if (item == null) return false;
+
+            var selfVisible = IsCheckboxPassForItem(item) && !IsFilteredOutByText(GetItemSearchText(item));
+            var anyChild = false;
+            foreach (var childObj in node.Items)
+            {
+                if (childObj is TreeViewItem child)
+                    anyChild |= ApplyTreeFilterRecursive(child);
             }
 
-            return isFilteredOut;
+            var show = selfVisible || anyChild;
+            node.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+            return show;
+        }
+
+        private bool IsCheckboxPassForItem(Item item)
+        {
+            if (item.ItemSort == ItemSortType.Item || item.ItemSort == ItemSortType.Unique ||
+                item.ItemSort == ItemSortType.Other)
+                return ShowOtherCheckBox.IsChecked == true;
+
+            foreach (var c in ShowWrapPanel.Children.OfType<CheckBox>())
+            {
+                if (c.Tag is ItemSortType t && t == item.ItemSort)
+                    return c.IsChecked == true;
+            }
+
+            return false;
+        }
+
+        private bool IsFilteredOutByText(string searchBlob)
+        {
+            if (string.IsNullOrWhiteSpace(SearchTextBox.Text)) return false;
+            var searchTerms = SearchTextBox.Text.ToLowerInvariant().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var s in searchTerms)
+            {
+                if (!searchBlob.Contains(s)) return true;
+            }
+
+            return false;
         }
 
         private void CheckAllButton_OnClick(object sender, RoutedEventArgs e)
@@ -317,15 +391,17 @@ namespace D_OS_Save_Editor
             return TryApplySelectedItemChanges(null);
         }
 
+        private static string ItemChangeKey(Item item) => item.ItemXmlNodeIdx.ToString();
+
         private bool TryApplySelectedItemChanges(Button toolTipButton)
         {
-            if (ItemsListBox.SelectedIndex < 0)
+            if (_selectedItemIndex < 0 || _selectedItemIndex >= Player.Items.Length)
                 return false;
 
             try
             {
-                // apply changes to a copy of the item
-                var item = Player.Items[ItemsListBox.SelectedIndex].DeepClone();
+                var previousTreeRef = Player.Items[_selectedItemIndex];
+                var item = previousTreeRef.DeepClone();
                 var allowedChanges = item.GetAllowedChangeType();
                 if (allowedChanges.Contains(nameof(item.Amount)))
                     item.Amount = AmountTextBox.Text;
@@ -338,9 +414,9 @@ namespace D_OS_Save_Editor
                     item.Vitality = VitalityTextBox.Text;
                     item.MaxVitalityPatchCheck = MaxVitalityPatchCheckTextBox.Text;
                 }
-                
+
                 if (allowedChanges.Contains(nameof(item.ItemRarity)))
-                    item.ItemRarity = (Item.ItemRarityType) RarityComboBox.SelectedIndex;
+                    item.ItemRarity = (Item.ItemRarityType)RarityComboBox.SelectedIndex;
 
                 if (allowedChanges.Contains(nameof(item.Stats)))
                 {
@@ -354,8 +430,6 @@ namespace D_OS_Save_Editor
                 {
                     if (item.Generation == null)
                     {
-                        //TODO if Item.Stats is null, an error will occur later on when writing xml because Geneartion.Level is taken from Stats.Level.
-                        //Since Item.Stats == null is not likely to be possible, let's handle it later on if we have an report of this case.
                         if (item.Stats == null)
                         {
                             var xmlSerializer = new XmlSerializer(item.GetType());
@@ -373,28 +447,23 @@ namespace D_OS_Save_Editor
 
                     item.Generation.Boosts = new List<string>();
                     foreach (string s in BoostsListBox.Items)
-                    {
                         item.Generation.Boosts.Add(s);
-                    }
                 }
 
-                // add changes
-                if (Player.ItemChanges.ContainsKey(item.Slot))
-                {
-                    Player.ItemChanges[item.Slot] = new ItemChange(item, Player.ItemChanges[item.Slot].ChangeType);
-                }
+                var key = ItemChangeKey(item);
+                if (Player.ItemChanges.ContainsKey(key))
+                    Player.ItemChanges[key] = new ItemChange(item, Player.ItemChanges[key].ChangeType);
                 else
+                    Player.ItemChanges.Add(key, new ItemChange(item, ChangeType.Modify));
+
+                Player.Items[_selectedItemIndex] = item;
+
+                var tvi = FindTreeViewItemForItem(previousTreeRef);
+                if (tvi != null)
                 {
-                    Player.ItemChanges.Add(item.Slot,
-                        new ItemChange(item, ChangeType.Modify));
+                    tvi.Tag = item;
+                    tvi.Foreground = _itemRarityColor[(int)item.ItemRarity];
                 }
-
-                // apply changes to the original item
-                Player.Items[ItemsListBox.SelectedIndex] = item;
-
-                // change colour
-                ((ListBoxItem) ItemsListBox.Items[ItemsListBox.SelectedIndex]).Foreground =
-                    _itemRarityColor[(int) item.ItemRarity];
 
                 if (toolTipButton != null)
                 {
@@ -431,35 +500,57 @@ namespace D_OS_Save_Editor
             }
         }
 
+        private TreeViewItem FindTreeViewItemForItem(Item target)
+        {
+            foreach (TreeViewItem root in ItemsTreeView.Items)
+            {
+                var f = FindTreeViewItemRecursive(root, target);
+                if (f != null) return f;
+            }
+            return null;
+        }
+
+        private static TreeViewItem FindTreeViewItemRecursive(TreeViewItem node, Item target)
+        {
+            if (node.Tag is Item it && ReferenceEquals(it, target))
+                return node;
+            foreach (TreeViewItem child in node.Items)
+            {
+                var f = FindTreeViewItemRecursive(child, target);
+                if (f != null) return f;
+            }
+            return null;
+        }
+
         private void BoostsContextMenu_Click(object sender, RoutedEventArgs e)
         {
             switch (((MenuItem)sender).Header)
             {
                 case "Add":
-                    // try pre-determine equipment type
                     var predictedKeyword = "";
-                    var boostsString= BoostsListBox.Items.Cast<string>().Aggregate("", (current, s) => current + s);
-                    boostsString += Player.Items[ItemsListBox.SelectedIndex].StatsName.ToLower();
+                    var boostsString = BoostsListBox.Items.Cast<string>().Aggregate("", (current, s) => current + s);
+                    if (_selectedItemIndex >= 0 && _selectedItemIndex < Player.Items.Length)
+                        boostsString += Player.Items[_selectedItemIndex].StatsName.ToLower();
 
-                    if (boostsString!="")
-                    foreach (var s in DataTable.GenerationBoostsFilterNames)
-                    {
-                        if (!boostsString.Contains(s)) continue;
-                        switch (s)
+                    if (boostsString != "")
+                        foreach (var s in DataTable.GenerationBoostsFilterNames)
                         {
-                            case "arm":
-                                predictedKeyword += "armor ";
-                                break;
-                            case "wpn":
-                                predictedKeyword += "weapon ";
-                                break;
-                            default:
-                                predictedKeyword += s + " ";
-                                break;
+                            if (!boostsString.Contains(s)) continue;
+                            switch (s)
+                            {
+                                case "arm":
+                                    predictedKeyword += "armor ";
+                                    break;
+                                case "wpn":
+                                    predictedKeyword += "weapon ";
+                                    break;
+                                default:
+                                    predictedKeyword += s + " ";
+                                    break;
+                            }
                         }
-                    }
 
-                    var dlg=new AddBoostDialog(predictedKeyword);
+                    var dlg = new AddBoostDialog(predictedKeyword);
                     dlg.ShowDialog();
                     if (dlg.DialogResult == true)
                     {
@@ -479,20 +570,26 @@ namespace D_OS_Save_Editor
 
         private void SearchTextBox_OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            foreach (ListBoxItem i in ItemsListBox.Items)
-            {
-                var listBoxText = ((string)i.Content).ToLower();
-                var searchTerms = SearchTextBox.Text.ToLower().Split(' ');
-                var visiblily = Visibility.Visible;
-                foreach (var s in searchTerms)
-                {
-                    if (listBoxText.Contains(s)) continue;
+            ApplyTreeFilter();
+        }
 
-                    visiblily = Visibility.Collapsed;
-                    break;
-                }
-                i.Visibility = visiblily;
-            }
+        private void TextBoxEventSetter_OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            if (!(sender is TextBox s)) return;
+            if (s.Uid == "SearchText") return;
+
+            var text = s.Text;
+            var valid = int.TryParse(text, out int _);
+            s.BorderBrush = !valid ? Brushes.Red : DefaultTextBoxBorderBrush;
+        }
+
+        private void TextBoxEventSetter_OnPreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            if (!(sender is TextBox s)) return;
+            if (s.Uid == "SearchText") return;
+
+            var text = s.Text.Insert(s.SelectionStart, e.Text);
+            e.Handled = !int.TryParse(text, out int _);
         }
     }
 }

--- a/D-OS Save Editor/SE/SaveEditor.xaml
+++ b/D-OS Save Editor/SE/SaveEditor.xaml
@@ -90,9 +90,12 @@
 
         <StackPanel Grid.Row="1" Orientation="Horizontal">
             <ComboBox x:Name="PlayerSelectionComboBox" HorizontalAlignment="Left" Margin="20,20,0,0" VerticalAlignment="Top" Width="120" Height="21.24" SelectionChanged="PlayerSelectionComboBox_OnSelectionChanged"/>
-            <Button x:Name="SavePlayer" Content="Apply" Width="60" Margin="20,20,0,0" Click="SavePlayer_OnClick" ToolTip="Apply changes made to the selected charactor"/>
+            <Button x:Name="SavePlayer" Content="Apply" Width="60" Margin="20,20,0,0" Click="SavePlayer_OnClick" ToolTip="Apply changes made to the selected charactor" IsEnabled="False"/>
+            <TextBlock x:Name="CharacterApplyPendingLabel" Text="Unapplied edits" Foreground="#CC6600" FontWeight="SemiBold" VerticalAlignment="Center" Margin="8,20,0,0" Visibility="Collapsed"/>
         </StackPanel>
         <StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
+            <TextBlock x:Name="UnsavedChangesLabel" Text="Not saved to file" Visibility="Collapsed"
+                       Foreground="#CC6600" VerticalAlignment="Center" Margin="0,20,12,0" FontWeight="SemiBold"/>
             <Button x:Name="ResetButton" Content="Reset" VerticalAlignment="Center" Padding="10,2" Margin ="10,20,40,0" Width="60" Click="ResetButton_OnClick"/>
             <Button x:Name="SaveButton" Content="Save" VerticalAlignment="Center" Padding="10,2" Margin="0,20,0,0" Width="60" Click="SaveButton_OnClick"/>
             <Button x:Name="CancelButton" Content="Cancel" VerticalAlignment="Center" Padding="10,2" Margin ="10,20,20,0" Width="60" IsCancel="True"/>

--- a/D-OS Save Editor/SE/SaveEditor.xaml
+++ b/D-OS Save Editor/SE/SaveEditor.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:D_OS_Save_Editor"
         mc:Ignorable="d"
-        Title="D-OS Save Editor: Save editor" SizeToContent="WidthAndHeight" MaxWidth="850" Width="655.916" WindowStartupLocation="CenterOwner"
+        Title="D-OS Save Editor: Save editor" SizeToContent="WidthAndHeight" MaxWidth="980" Width="740" WindowStartupLocation="CenterOwner"
         Closed="SaveEditor_OnClosed" Closing="SaveEditor_OnClosing"
         UseLayoutRounding="True">
     <Window.Resources>

--- a/D-OS Save Editor/SE/SaveEditor.xaml.cs
+++ b/D-OS Save Editor/SE/SaveEditor.xaml.cs
@@ -16,6 +16,8 @@ namespace D_OS_Save_Editor
         private Savegame Savegame { get; set; }
         private Player[] EditingPlayers { get; set; }
 
+        private string _baseTitle;
+        private bool _hasUnsavedChanges;
 
         public SaveEditor(string jsonFile)
         {
@@ -40,6 +42,8 @@ namespace D_OS_Save_Editor
             }
 
             PlayerSelectionComboBox.SelectedIndex = 0;
+            _baseTitle = Title;
+            SetUnsavedChanges(false);
         }
 
         public SaveEditor(Savegame savegame)
@@ -47,7 +51,8 @@ namespace D_OS_Save_Editor
             InitializeComponent();
             Savegame = savegame;
 
-            Title = $"D-OS Save Editor: {savegame.SavegameName.Substring(0,savegame.SavegameName.Length-4)}";
+            _baseTitle = $"D-OS Save Editor: {savegame.SavegameName.Substring(0, savegame.SavegameName.Length - 4)}";
+            Title = _baseTitle;
 
             // make a copy of players
             try
@@ -67,6 +72,33 @@ namespace D_OS_Save_Editor
             }
 
             PlayerSelectionComboBox.SelectedIndex = 0;
+            SetUnsavedChanges(false);
+        }
+
+        /// <summary>
+        /// Call when tab Apply or inventory apply commits edits to the in-memory save (still need Save to write .lsv).
+        /// </summary>
+        public void MarkUnsavedSessionChanges()
+        {
+            SetUnsavedChanges(true);
+        }
+
+        private void SetUnsavedChanges(bool dirty)
+        {
+            _hasUnsavedChanges = dirty;
+            if (!string.IsNullOrEmpty(_baseTitle))
+                Title = dirty ? $"{_baseTitle} *" : _baseTitle;
+            if (UnsavedChangesLabel != null)
+                UnsavedChangesLabel.Visibility = dirty ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public void RefreshCharacterApplyPendingState()
+        {
+            var pending = StatsTab.HasPendingEdits() || AbilitiesTab.HasPendingEdits() || TraitsTab.HasPendingEdits() ||
+                          TalentTab.HasPendingEdits();
+            SavePlayer.IsEnabled = pending;
+            if (CharacterApplyPendingLabel != null)
+                CharacterApplyPendingLabel.Visibility = pending ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void ShowContent(int id)
@@ -81,6 +113,8 @@ namespace D_OS_Save_Editor
             {
                 //TraitsTab.IsEnabled = false;
             }
+            RefreshCharacterApplyPendingState();
+            InventoryTab.RefreshInventoryApplyUi();
         }
 
         private void PlayerSelectionComboBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -94,6 +128,12 @@ namespace D_OS_Save_Editor
             try
             {
                 Cursor = Cursors.Wait;
+                if (!InventoryTab.TryApplyPendingInventoryForMainSave())
+                {
+                    Cursor = Cursors.Arrow;
+                    SaveButton.IsEnabled = true;
+                    return;
+                }
                 StatsTab.SaveEdits();
                 AbilitiesTab.SaveEdits();
                 TraitsTab.SaveEdits();
@@ -113,7 +153,9 @@ namespace D_OS_Save_Editor
                 await Savegame.WriteEditsToLsxAsync(progress);
                 // pack up files
                 await Savegame.PackSavegameAsync(progress);
-                
+
+                SetUnsavedChanges(false);
+
                 progressIndicator.ProgressText = "Successful.";
                 progressIndicator.CanCancel = true;
                 progressIndicator.CancelButtonText = "Close";
@@ -139,6 +181,9 @@ namespace D_OS_Save_Editor
             StatsTab.UpdateForm();
             AbilitiesTab.UpdateForm();
             InventoryTab.UpdateForm();
+            SetUnsavedChanges(false);
+            RefreshCharacterApplyPendingState();
+            InventoryTab.RefreshInventoryApplyUi();
         }
 
         private void SaveEditor_OnClosed(object sender, EventArgs e)
@@ -177,7 +222,6 @@ namespace D_OS_Save_Editor
         
         private void SavePlayer_OnClick(object sender, RoutedEventArgs e)
         {
-            SavePlayer.IsEnabled = false;
             try
             {
                 StatsTab.SaveEdits();
@@ -186,16 +230,13 @@ namespace D_OS_Save_Editor
                 TalentTab.SaveEdits();
 
                 MessageBox.Show(this, "Changes have been applied to the selected character.", "Successful");
+                MarkUnsavedSessionChanges();
+                RefreshCharacterApplyPendingState();
             }
             catch (Exception ex)
             {
-                SavePlayer.IsEnabled = true;
                 var er = new ErrorReporting($"Failed to save changes.\n\n{ex}", null);
                 er.ShowDialog();
-            }
-            finally
-            {
-                SavePlayer.IsEnabled = true;
             }
         }
 
@@ -210,11 +251,32 @@ namespace D_OS_Save_Editor
 
         private void SaveEditor_OnClosing(object sender, CancelEventArgs e)
         {
-            //if ()
-            //{
-            //    var result = MessageBox.Show(this, "You have unsaved changes. Do you want to close the window now?",
-            //        "Unsaved changes", MessageBoxButton.YesNo, MessageBoxImage.Warning);
-            //}
+            var unapplied = StatsTab.HasPendingEdits() || AbilitiesTab.HasPendingEdits() || TraitsTab.HasPendingEdits() ||
+                            TalentTab.HasPendingEdits() || InventoryTab.HasPendingItemDetailEdits();
+            if (unapplied)
+            {
+                var r1 = MessageBox.Show(this,
+                    "You have edited fields that are not applied yet (use Apply on the character tabs or Apply changes on inventory). Close anyway and lose those edits?",
+                    "Unapplied edits",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Warning);
+                if (r1 == MessageBoxResult.No)
+                {
+                    e.Cancel = true;
+                    return;
+                }
+            }
+
+            if (!_hasUnsavedChanges) return;
+
+            var result = MessageBox.Show(this,
+                "You have changes that are not saved to the save file yet (use Save). Close anyway and discard those changes?",
+                "Unsaved changes",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning);
+
+            if (result == MessageBoxResult.No)
+                e.Cancel = true;
         }
 
         private void BugReportButton_OnClick(object sender, RoutedEventArgs e)

--- a/D-OS Save Editor/SE/StatsTab.xaml
+++ b/D-OS Save Editor/SE/StatsTab.xaml
@@ -13,6 +13,7 @@
             <Setter Property="VerticalAlignment" Value="Top"/>
             <EventSetter Event="LostFocus" Handler="TextBoxEventSetter_OnLostFocus"/>
             <EventSetter Event="PreviewTextInput" Handler="TextBoxEventSetter_OnPreviewTextInput"/>
+            <EventSetter Event="TextChanged" Handler="CharacterField_TextChanged"/>
         </Style>
     </UserControl.Resources>
     <StackPanel>

--- a/D-OS Save Editor/SE/StatsTab.xaml.cs
+++ b/D-OS Save Editor/SE/StatsTab.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Controls.Primitives;
 
 namespace D_OS_Save_Editor
 {
@@ -11,6 +12,7 @@ namespace D_OS_Save_Editor
     public partial class StatsTab
     {
         private Player _player;
+        private bool _suppressFieldEvents;
         private Brush DefaultTextBoxBorderBrush { get; }
 
         public Player Player
@@ -30,8 +32,38 @@ namespace D_OS_Save_Editor
             DefaultTextBoxBorderBrush = ExpTextBox.BorderBrush;
         }
 
+
+        public bool HasPendingEdits()
+        {
+            if (Player == null) return false;
+            if (ExpTextBox.Text != Player.Experience) return true;
+            if (ReputationTextBox.Text != Player.Reputation) return true;
+            if (HpCurrentTextBox.Text != Player.Vitality) return true;
+            if (HpMaxTextBox.Text != Player.MaxVitalityPatchCheck) return true;
+            if (AttributePointsTextBox.Text != Player.AttributePoints) return true;
+            if (AbilityPointsTextBox.Text != Player.AbilityPoints) return true;
+            if (TalentPointsTextBox.Text != Player.TalentPoints) return true;
+            if (StrengthTextBox.Text != Player.Attributes[(int)DataTable.Attributes.Strength].ToString()) return true;
+            if (DexterityTextBox.Text != Player.Attributes[(int)DataTable.Attributes.Dexerity].ToString()) return true;
+            if (IntelligenceTextBox.Text != Player.Attributes[(int)DataTable.Attributes.Intelligence].ToString()) return true;
+            if (ConstitutionTextBox.Text != Player.Attributes[(int)DataTable.Attributes.Consitution].ToString()) return true;
+            if (SpeedTextBox.Text != Player.Attributes[(int)DataTable.Attributes.Speed].ToString()) return true;
+            if (PerceptionTextBox.Text != Player.Attributes[(int)DataTable.Attributes.Perception].ToString()) return true;
+            return false;
+        }
+
+        private void CharacterField_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (_suppressFieldEvents) return;
+            if (Window.GetWindow(this) is SaveEditor editor)
+                editor.RefreshCharacterApplyPendingState();
+        }
+
         public void UpdateForm()
         {
+            _suppressFieldEvents = true;
+            try
+            {
             ExpTextBox.Text = Player.Experience;
             ReputationTextBox.Text = Player.Reputation;
             HpCurrentTextBox.Text = Player.Vitality;
@@ -45,6 +77,11 @@ namespace D_OS_Save_Editor
             ConstitutionTextBox.Text = Player.Attributes[(int)DataTable.Attributes.Consitution].ToString();
             SpeedTextBox.Text = Player.Attributes[(int)DataTable.Attributes.Speed].ToString();
             PerceptionTextBox.Text = Player.Attributes[(int)DataTable.Attributes.Perception].ToString();
+            }
+            finally
+            {
+                _suppressFieldEvents = false;
+            }
         }
 
         public void SaveEdits()

--- a/D-OS Save Editor/SE/TalentTab.xaml.cs
+++ b/D-OS Save Editor/SE/TalentTab.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 
@@ -13,6 +14,7 @@ namespace D_OS_Save_Editor
     public partial class TalentTab
     {
         private Player _player;
+        private bool _suppressTalentEvents;
         public Player Player
         {
             get => _player;
@@ -27,6 +29,30 @@ namespace D_OS_Save_Editor
         public TalentTab()
         {
             InitializeComponent();
+        }
+
+        public bool HasPendingEdits()
+        {
+            if (Player == null || TalentGroup0.Children.Count + TalentGroup1.Children.Count == 0)
+                return false;
+            var checkedTalents = new bool[DataTable.TalentIsHidden.Length];
+            foreach (CheckBox ckb in TalentGroup0.Children)
+                checkedTalents[(int)ckb.Tag] = ckb.IsChecked == true;
+            foreach (CheckBox ckb in TalentGroup1.Children)
+                checkedTalents[(int)ckb.Tag] = ckb.IsChecked == true;
+            var bytes = new byte[12];
+            new BitArray(checkedTalents).CopyTo(bytes, 0);
+            var t0 = BitConverter.ToUInt32(bytes, 0);
+            var t1 = BitConverter.ToUInt32(bytes, 4);
+            var t2 = BitConverter.ToUInt32(bytes, 8);
+            return t0 != Player.Talents[0] || t1 != Player.Talents[1] || t2 != Player.Talents[2];
+        }
+
+        private void TalentCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_suppressTalentEvents) return;
+            if (Window.GetWindow(this) is SaveEditor editor)
+                editor.RefreshCharacterApplyPendingState();
         }
 
         public void SaveEdits()
@@ -51,6 +77,9 @@ namespace D_OS_Save_Editor
 
         private void UpdateForm()
         {
+            _suppressTalentEvents = true;
+            try
+            {
             TalentGroup0.Children.Clear();
             TalentGroup1.Children.Clear();
 
@@ -73,19 +102,26 @@ namespace D_OS_Save_Editor
                 //    toolTipContent = talent.Effect;
                 //}
 
-                panel.Children.Add(
-                    new CheckBox
+                var ckb = new CheckBox
                     {
                         Content = talent.Name,
                         Tag = talent.Index,
                         ToolTip = talent.Effect,
                         IsChecked = playerTalentIds.Contains(talent.Index)
-                    });
+                    };
+                    ckb.Checked += TalentCheckBox_Changed;
+                    ckb.Unchecked += TalentCheckBox_Changed;
+                    panel.Children.Add(ckb);
             }
 
             foreach (var talent in talentArray)
             {
                 AddToPanel(talent.IsHidden ? TalentGroup1 : TalentGroup0, talent);
+            }
+            }
+            finally
+            {
+                _suppressTalentEvents = false;
             }
         }
 

--- a/D-OS Save Editor/SE/TraitCouple.xaml
+++ b/D-OS Save Editor/SE/TraitCouple.xaml
@@ -37,8 +37,8 @@
                 </Style>
             </TextBlock.Style>
         </TextBlock>
-        <TextBox x:Name="LeftTextBox" Grid.Column="1" Text="{Binding LeftTrait.Value, UpdateSourceTrigger=PropertyChanged}" Margin="10,0" VerticalAlignment="Center" Width="20"/>
-        <TextBox x:Name="RightTextBox" Grid.Column="3" Text="{Binding RightTrait.Value, UpdateSourceTrigger=PropertyChanged}" Margin="10,0" VerticalAlignment="Center" Width="20"/>
+        <TextBox x:Name="LeftTextBox" Grid.Column="1" Text="{Binding LeftTrait.Value, UpdateSourceTrigger=PropertyChanged}" Margin="10,0" VerticalAlignment="Center" Width="20" TextChanged="TraitValue_TextChanged"/>
+        <TextBox x:Name="RightTextBox" Grid.Column="3" Text="{Binding RightTrait.Value, UpdateSourceTrigger=PropertyChanged}" Margin="10,0" VerticalAlignment="Center" Width="20" TextChanged="TraitValue_TextChanged"/>
         <Slider x:Name="Slider" Value="{Binding SliderValue, Mode=OneWay}" Grid.Column="2" VerticalAlignment="Center" Margin="10,5" Minimum="-1" Maximum="1" TickFrequency="1" TickPlacement="Both" Width="200" IsEnabled="False"/>
     </Grid>
 </UserControl>

--- a/D-OS Save Editor/SE/TraitCouple.xaml.cs
+++ b/D-OS Save Editor/SE/TraitCouple.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Windows.Controls;
+using System.Windows;
 using System.Windows.Media;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using D_OS_Save_Editor.Annotations;
 
 namespace D_OS_Save_Editor
@@ -12,6 +14,18 @@ namespace D_OS_Save_Editor
     public partial class TraitCouple : UserControl
     {
         private Brush DefaultTextBoxBorderBrush { get; }
+
+
+        private void TraitValue_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            for (DependencyObject p = this; p != null; p = System.Windows.Media.VisualTreeHelper.GetParent(p))
+            {
+                if (p is TraitsTab traits && traits.SuppressTraitNotifications)
+                    return;
+            }
+            if (Window.GetWindow(this) is SaveEditor editor)
+                editor.RefreshCharacterApplyPendingState();
+        }
 
         public TraitCouple(Trait leftTrait, Trait rightTrait)
         {

--- a/D-OS Save Editor/SE/TraitsTab.xaml.cs
+++ b/D-OS Save Editor/SE/TraitsTab.xaml.cs
@@ -18,14 +18,33 @@
         }
 
         private TraitCouple[] _traitCouples;
+        public bool SuppressTraitNotifications { get; private set; }
 
         public TraitsTab()
         {
             InitializeComponent();
         }
 
+
+        public bool HasPendingEdits()
+        {
+            if (Player == null || _traitCouples == null) return false;
+            for (var i = 0; i < DataTable.TraitNames.Length / 2; i++)
+            {
+                if (_traitCouples[i] == null) continue;
+                var tc = _traitCouples[i].DataContext as TraitCoupleViewModel;
+                if (tc == null) continue;
+                if (tc.LeftTrait.Value != Player.Traits[2 * i].ToString()) return true;
+                if (tc.RightTrait.Value != Player.Traits[2 * i + 1].ToString()) return true;
+            }
+            return false;
+        }
+
         public void UpdateForm()
         {
+            SuppressTraitNotifications = true;
+            try
+            {
             _traitCouples = new TraitCouple[DataTable.TraitNames.Length / 2];
             StackPanel.Children.Clear();
 
@@ -39,12 +58,18 @@
 
                 StackPanel.Children.Add(_traitCouples[i]);
             }
+            }
+            finally
+            {
+                SuppressTraitNotifications = false;
+            }
         }
 
         public void SaveEdits()
         {
             for (var i = 0; i < DataTable.TraitNames.Length / 2; i++)
             {
+                if (_traitCouples[i] == null) continue;
                 var tc = _traitCouples[i].DataContext as TraitCoupleViewModel;
                 Player.Traits[2 * i] = int.Parse(tc.LeftTrait.Value);
                 Player.Traits[2 * i + 1] = int.Parse(tc.RightTrait.Value);

--- a/D-OS Save Editor/savegame/DataTable.cs
+++ b/D-OS Save Editor/savegame/DataTable.cs
@@ -1,8 +1,16 @@
-﻿namespace D_OS_Save_Editor
+﻿using System;
+
+namespace D_OS_Save_Editor
 {
     public class DataTable
     {
         public const string SupportedGameVersion = "2.0.119.430";
+
+        /// <summary>
+        /// Inventory slot indices 0..(EquipmentPaperDollSlotCount-1) on the character's main inventory are paper-doll equipment; higher slots are bag/grid.
+        /// Matches typical EquipmentSlots count on inventory nodes (15).
+        /// </summary>
+        public const int EquipmentPaperDollSlotCount = 15;
 
         public enum Attributes
         {
@@ -339,6 +347,29 @@
         /// Names used for Arrow category items. Arrow items have prefix WPN which is shared with the Weapon category. Therefore, we need these strings to identify the Arrow category.
         /// </summary>
         public static readonly string[] ArrowTypeNames = {"arrow", "arrowhead", "arrowshaft"};
+
+        /// <summary>
+        /// Exact Stats ids for bags/chests/pouches (lowercase). Not exhaustive — also match <see cref="IsContainerStatsName"/> prefixes cont_ and gen_container_.
+        /// There is no bundled list in LSLib; extend from game data or saves as needed.
+        /// </summary>
+        public static readonly string[] ContainerStatsExactNames =
+        {
+            "cont_backpack_a",
+            "cont_backpack_a_sourcehunter",
+            "gen_container_indestructible"
+        };
+
+        /// <summary>
+        /// True if this stats id should be categorized as a container (backpack, pouch, chest, etc.).
+        /// </summary>
+        public static bool IsContainerStatsName(string statsLower)
+        {
+            if (string.IsNullOrEmpty(statsLower)) return false;
+            if (System.Array.IndexOf(ContainerStatsExactNames, statsLower) >= 0) return true;
+            if (statsLower.StartsWith("cont_", StringComparison.Ordinal)) return true;
+            if (statsLower.StartsWith("gen_container_", StringComparison.Ordinal)) return true;
+            return false;
+        }
 
         public static string[] TraitNames =
         {

--- a/D-OS Save Editor/savegame/DataTable.cs
+++ b/D-OS Save Editor/savegame/DataTable.cs
@@ -327,7 +327,13 @@
         /// Names used for Gold category items
         /// </summary>
         public static readonly string[] GoldNames =
-            {"small_gold", "inbetween_gold", "trader_large_gold", "trader_insane_gold"};
+        {
+            "small_gold",
+            "inbetween_gold",
+            "larger_gold",
+            "trader_large_gold",
+            "trader_insane_gold"
+        };
 
         /// <summary>
         /// Names used for Arrow category items. Arrow items have prefix WPN which is shared with the Weapon category. Therefore, we need these strings to identify the Arrow category.

--- a/D-OS Save Editor/savegame/Item.cs
+++ b/D-OS Save Editor/savegame/Item.cs
@@ -248,6 +248,33 @@ namespace D_OS_Save_Editor
 
         }
 
+
+
+        /// <summary>
+        /// Whether Amount (stack count) may be edited. Disabled for weapons, armor, furniture, quest items, keys, and Unique rarity.
+        /// </summary>
+        private bool IsAmountEditable()
+        {
+            switch (ItemSort)
+            {
+                case ItemSortType.Weapon:
+                case ItemSortType.Armor:
+                case ItemSortType.Furniture:
+                case ItemSortType.Quest:
+                case ItemSortType.Key:
+                    return false;
+            }
+
+            // Stats ids use arm_* for armor; keep Amount locked if sort was misclassified (e.g. item_* armor).
+            if (!string.IsNullOrEmpty(StatsName) &&
+                StatsName.StartsWith("arm_", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            if (ItemRarity == ItemRarityType.Unique)
+                return false;
+
+            return true;
+        }
         /// <summary>
         /// Get the names of the properties that can be safely and meaningfully changed.
         /// </summary>
@@ -266,14 +293,8 @@ namespace D_OS_Save_Editor
                 s += nameof(Generation);
             }
 
-            if (ItemSort == ItemSortType.Potion ||
-                ItemSort == ItemSortType.Gold ||
-                ItemSort == ItemSortType.Granade ||
-                ItemSort == ItemSortType.Scroll ||
-                ItemSort == ItemSortType.Food)
-            {
+            if (IsAmountEditable())
                 s += nameof(Amount);
-            }
 
             if (ItemSort == ItemSortType.Furniture)
             {

--- a/D-OS Save Editor/savegame/Item.cs
+++ b/D-OS Save Editor/savegame/Item.cs
@@ -12,7 +12,7 @@ namespace D_OS_Save_Editor
     /// <summary>
     /// Item category or type
     /// </summary>
-    public enum ItemSortType { Item = 0, Potion, Armor, Weapon, Gold, Skillbook, Scroll, Granade, Food, Furniture, Loot, Quest, Tool, Unique, Book, Other, Key, Arrow }
+    public enum ItemSortType { Item = 0, Potion, Armor, Weapon, Gold, Skillbook, Scroll, Granade, Food, Furniture, Loot, Quest, Tool, Unique, Book, Container, Other, Key, Arrow }
     public class Item
     {
         #region properties
@@ -224,6 +224,26 @@ namespace D_OS_Save_Editor
         /// Xml node name: stats of the item
         /// </summary>
         public StatsNode Stats { get; set; }
+
+        /// <summary>
+        /// Xml attribute id="Inventory": handle of this item's nested inventory (items whose Parent equals this). "0" if none.
+        /// </summary>
+        public string NestedInventoryId { get; set; } = "0";
+
+        /// <summary>
+        /// Optional friendly label from the save: id="DisplayName" or "Name" — resolved <c>value</c> if present, else Larian <c>handle</c> (h…;n).
+        /// </summary>
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// True if this item sits in the character's paper-doll equipment band (slot 0..EquipmentPaperDollSlotCount-1 on main inventory).
+        /// </summary>
+        public bool IsEquippedPaperDoll(string characterInventoryId)
+        {
+            if (characterInventoryId == null || Parent != characterInventoryId) return false;
+            if (!int.TryParse(Slot, out var slot)) return false;
+            return slot >= 0 && slot < DataTable.EquipmentPaperDollSlotCount;
+        }
         #endregion
 
         #region methods
@@ -262,6 +282,7 @@ namespace D_OS_Save_Editor
                 case ItemSortType.Furniture:
                 case ItemSortType.Quest:
                 case ItemSortType.Key:
+                case ItemSortType.Container:
                     return false;
             }
 

--- a/D-OS Save Editor/savegame/LsxParser.cs
+++ b/D-OS Save Editor/savegame/LsxParser.cs
@@ -12,6 +12,67 @@ namespace D_OS_Save_Editor
     [SuppressMessage("ReSharper", "AssignNullToNotNullAttribute")]
     public class LsxParser
     {
+        /// <summary>
+        /// LSX stores &lt;attribute id="..." type="..." value="..." /&gt;; value is not always Attributes[1]. Read the value attribute by name.
+        /// </summary>
+        private static string GetLsxAttributeValue(XmlNode attributeElement)
+        {
+            if (attributeElement?.Attributes == null) return null;
+            var byName = attributeElement.Attributes["value"];
+            if (byName != null) return byName.Value;
+            foreach (XmlAttribute a in attributeElement.Attributes)
+            {
+                if (string.Equals(a.LocalName, "value", StringComparison.OrdinalIgnoreCase))
+                    return a.Value;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Type 28 (TranslatedString) often stores only <c>handle</c> in the save; resolved <c>value</c> may be absent until load.
+        /// </summary>
+        private static string GetLsxAttributeValueOrHandle(XmlNode attributeElement)
+        {
+            var v = GetLsxAttributeValue(attributeElement);
+            if (!string.IsNullOrEmpty(v)) return v;
+            if (attributeElement?.Attributes == null) return null;
+            var h = attributeElement.Attributes["handle"];
+            if (h != null) return h.Value;
+            foreach (XmlAttribute a in attributeElement.Attributes)
+            {
+                if (string.Equals(a.LocalName, "handle", StringComparison.OrdinalIgnoreCase))
+                    return a.Value;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Sets the LSX <c>value=</c> attribute (not a fixed index — attribute order varies).
+        /// </summary>
+        private static void SetLsxAttributeValue(XmlNode parentNode, string attributeId, string value)
+        {
+            var attrEl = parentNode.SelectSingleNode($"attribute [@id='{attributeId}']");
+            if (attrEl?.Attributes == null)
+                throw new InvalidOperationException($"Missing attribute id='{attributeId}' on node.");
+            var v = attrEl.Attributes["value"];
+            if (v != null)
+            {
+                v.Value = value;
+                return;
+            }
+
+            foreach (XmlAttribute a in attrEl.Attributes)
+            {
+                if (string.Equals(a.LocalName, "value", StringComparison.OrdinalIgnoreCase))
+                {
+                    a.Value = value;
+                    return;
+                }
+            }
+
+            throw new InvalidOperationException($"Attribute id='{attributeId}' has no value=.");
+        }
+
         #region read file
         public static List<string> GenerationBoostCollector;
         public static List<string> StatsBoostsCollector;
@@ -39,46 +100,53 @@ namespace D_OS_Save_Editor
                     throw new PlayerParserException(e, playerData[i]);
                 }
 
-                // now we have the inventory id, we can get items
-                var inventoryData =
-                    doc.DocumentElement.SelectNodes($"//attribute [@id='Parent'] [@value='{players[i].InventoryId}']");
-                if (inventoryData == null)
-                    return;
+                // BFS: top-level inventory, then each nested container (child items' Parent = container's NestedInventoryId)
+                var itemList = new List<Item>();
+                var nodeList = new List<XmlNode>();
+                var expandQueue = new Queue<string>();
+                var expandedInventories = new HashSet<string>();
+                expandQueue.Enqueue(players[i].InventoryId);
 
-                players[i].Items = new Item[inventoryData.Count];
-                //var notAnItemIdx = new List<int>();
-                var notAnItemIdx = new ConcurrentQueue<int>();
-                Parallel.For(0, inventoryData.Count, j =>
+                while (expandQueue.Count > 0)
                 {
-                    Item item;
-                    try
-                    {
-                        item = ParseItem(inventoryData[j].ParentNode);
-                        item.ItemXmlNodeIdx = j;
-                    }
-                    catch (ObjectNullException)
-                    {
-                        notAnItemIdx.Enqueue(j);
-                        return;
-                    }
-                    catch (Exception e)
-                    {
-                        throw new ItemParserException(e, inventoryData[j].ParentNode);
-                    }
+                    var invId = expandQueue.Dequeue();
+                    if (!expandedInventories.Add(invId))
+                        continue;
 
-                    players[i].Items[j] = item;
-                    players[i].SlotsOccupation[int.Parse(item.Slot)] = true;
-                });
+                    var inventoryData =
+                        doc.DocumentElement.SelectNodes($"//attribute [@id='Parent'] [@value='{invId}']");
+                    if (inventoryData == null) continue;
 
-                if (notAnItemIdx.Count == 0) return;
+                    for (var j = 0; j < inventoryData.Count; j++)
+                    {
+                        var itemNode = inventoryData[j].ParentNode;
+                        Item item;
+                        try
+                        {
+                            item = ParseItem(itemNode);
+                            item.ItemXmlNodeIdx = itemList.Count;
+                        }
+                        catch (ObjectNullException)
+                        {
+                            continue;
+                        }
+                        catch (Exception e)
+                        {
+                            throw new ItemParserException(e, itemNode);
+                        }
 
-                // remove not an item entry
-                var items = new List<Item>(players[i].Items);
-                var list = notAnItemIdx.ToList();
-                list.Sort((a, b) => b.CompareTo(a));
-                foreach (var idx in list)
-                    items.RemoveAt(idx);
-                players[i].Items = items.ToArray();
+                        itemList.Add(item);
+                        nodeList.Add(itemNode);
+                        players[i].SlotsOccupation[int.Parse(item.Slot)] = true;
+
+                        var nested = item.NestedInventoryId;
+                        if (!string.IsNullOrEmpty(nested) && nested != "0")
+                            expandQueue.Enqueue(nested);
+                    }
+                }
+
+                players[i].Items = itemList.ToArray();
+                players[i].ItemXmlNodes = nodeList;
             });
             return players;
         }
@@ -165,13 +233,35 @@ namespace D_OS_Save_Editor
                 item.StatsName = node.SelectSingleNode("attribute [@id='Stats']").Attributes[1].Value;
                 item.Parent = node.SelectSingleNode("attribute [@id='Parent']").Attributes[1].Value;
                 item.Slot = node.SelectSingleNode("attribute [@id='Slot']").Attributes[1].Value;
-                item.Amount = node.SelectSingleNode("attribute [@id='Amount']").Attributes[1].Value;
+                var amountAttr = node.SelectSingleNode("attribute [@id='Amount']");
+                item.Amount = GetLsxAttributeValue(amountAttr) ?? amountAttr.Attributes[1].Value;
                 item.IsGenerated = node.SelectSingleNode("attribute [@id='IsGenerated']").Attributes[1].Value;
                 item.LockLevel = node.SelectSingleNode("attribute [@id='LockLevel']").Attributes[1].Value;
                 item.Vitality = node.SelectSingleNode("attribute [@id='Vitality']").Attributes[1].Value;
                 item.ItemType = node.SelectSingleNode("attribute [@id='ItemType']").Attributes[1].Value;
                 item.MaxVitalityPatchCheck = node.SelectSingleNode("attribute [@id='MaxVitalityPatchCheck']").Attributes[1].Value;
-                item.MaxDurabilityPatchCheck = node.SelectSingleNode("attribute [@id='MaxDurabilityPatchCheck']")?.Attributes[1].Value;
+                var maxDurAttr = node.SelectSingleNode("attribute [@id='MaxDurabilityPatchCheck']");
+                item.MaxDurabilityPatchCheck = maxDurAttr == null
+                    ? null
+                    : GetLsxAttributeValue(maxDurAttr) ?? maxDurAttr.Attributes[1].Value;
+
+                var invAttr = node.SelectSingleNode("attribute [@id='Inventory']");
+                item.NestedInventoryId = invAttr?.Attributes[1].Value ?? "0";
+
+                // Friendly label: DisplayName / Name — prefer resolved value, else Larian handle (h…;n) when only that is stored.
+                var displayNameAttr = node.SelectSingleNode("attribute [@id='DisplayName']") ??
+                                      node.SelectSingleNode(".//attribute [@id='DisplayName']");
+                var rawDisplay = GetLsxAttributeValueOrHandle(displayNameAttr);
+                item.DisplayName = string.IsNullOrWhiteSpace(rawDisplay) ? null : rawDisplay.Trim();
+
+                if (string.IsNullOrEmpty(item.DisplayName))
+                {
+                    var nameAttr = node.SelectSingleNode("attribute [@id='Name']") ??
+                                     node.SelectSingleNode("children//attribute [@id='Name']") ??
+                                     node.SelectSingleNode(".//attribute [@id='Name']");
+                    var rawName = GetLsxAttributeValueOrHandle(nameAttr);
+                    item.DisplayName = string.IsNullOrWhiteSpace(rawName) ? null : rawName.Trim();
+                }
             }
             catch (NullReferenceException e)
             {
@@ -183,6 +273,8 @@ namespace D_OS_Save_Editor
                 item.ItemSort = ItemSortType.Key;
             else if (DataTable.GoldNames.Contains(item.StatsName.ToLower()))
                 item.ItemSort = ItemSortType.Gold;
+            else if (DataTable.IsContainerStatsName(item.StatsName.ToLower()))
+                item.ItemSort = ItemSortType.Container;
             else
             {
                 var nameParts = item.StatsName.ToLower().Split('_');
@@ -342,7 +434,8 @@ namespace D_OS_Save_Editor
             if (playerData == null)
                 throw new XmlException("Unable to find any player data in the savegame.");
 
-            Parallel.For(0, playerData.Count, i =>
+            // Sequential: XmlDocument is not safe for concurrent writes; item edits must target this loaded doc.
+            for (var i = 0; i < playerData.Count; i++)
             {
                 playerData[i].ParentNode.ParentNode.SelectSingleNode("attribute [@id='MaxVitalityPatchCheck']")
                     .Attributes[1].Value = players[i].MaxVitalityPatchCheck;
@@ -395,16 +488,73 @@ namespace D_OS_Save_Editor
 
                 // write item changes
                 doc = WriteItemChanges(doc, players[i]);
-            });
+            }
 
             return doc;
         }
 
+        /// <summary>
+        /// Replays the same BFS inventory walk as <see cref="ParsePlayer"/> so we get live <see cref="XmlNode"/>
+        /// references into <paramref name="doc"/>. Required for save: <see cref="Savegame.WriteEditsToLsxAsync"/>
+        /// loads a new <see cref="XmlDocument"/>; cached <see cref="Player.ItemXmlNodes"/> point at the old tree.
+        /// </summary>
+        private static List<XmlNode> CollectItemXmlNodesForPlayer(XmlDocument doc, Player player)
+        {
+            var nodeList = new List<XmlNode>();
+            var expandQueue = new Queue<string>();
+            var expandedInventories = new HashSet<string>();
+            expandQueue.Enqueue(player.InventoryId);
+
+            while (expandQueue.Count > 0)
+            {
+                var invId = expandQueue.Dequeue();
+                if (!expandedInventories.Add(invId))
+                    continue;
+
+                var inventoryData =
+                    doc.DocumentElement.SelectNodes($"//attribute [@id='Parent'] [@value='{invId}']");
+                if (inventoryData == null) continue;
+
+                for (var j = 0; j < inventoryData.Count; j++)
+                {
+                    var itemNode = inventoryData[j].ParentNode;
+                    Item item;
+                    try
+                    {
+                        item = ParseItem(itemNode);
+                    }
+                    catch (ObjectNullException)
+                    {
+                        continue;
+                    }
+                    catch (Exception e)
+                    {
+                        throw new ItemParserException(e, itemNode);
+                    }
+
+                    nodeList.Add(itemNode);
+
+                    var nested = item.NestedInventoryId;
+                    if (!string.IsNullOrEmpty(nested) && nested != "0")
+                        expandQueue.Enqueue(nested);
+                }
+            }
+
+            return nodeList;
+        }
+
         public static XmlDocument WriteItemChanges(XmlDocument doc, Player player)
         {
-            // get all items belong to this player
-            // find item data
-            var inventoryData = doc.DocumentElement.SelectNodes($"//attribute [@id='Parent'] [@value='{player.InventoryId}']");
+            if (player.ItemChanges == null || player.ItemChanges.Count == 0)
+                return doc;
+
+            if (player.Items == null)
+                throw new InvalidOperationException("Player.Items is null.");
+
+            var itemNodes = CollectItemXmlNodesForPlayer(doc, player);
+            if (itemNodes.Count != player.Items.Length)
+                throw new InvalidOperationException(
+                    $"Item XML node count ({itemNodes.Count}) must match Player.Items length ({player.Items.Length}) when writing inventory.");
 
             foreach (var ic in player.ItemChanges)
             {
@@ -420,35 +570,25 @@ namespace D_OS_Save_Editor
                     }
                     else if (ic.Value.ChangeType == ChangeType.Modify)
                     {
-                        var itemNode = inventoryData[ic.Value.Item.ItemXmlNodeIdx].ParentNode;
+                        var itemNode = itemNodes[ic.Value.Item.ItemXmlNodeIdx];
 
                         var allowedChanges = ic.Value.Item.GetAllowedChangeType();
                         if (allowedChanges.Contains(nameof(ic.Value.Item.Amount)))
-                            itemNode.SelectSingleNode("attribute [@id='Amount']").Attributes[1].Value =
-                                ic.Value.Item.Amount;
+                            SetLsxAttributeValue(itemNode, "Amount", ic.Value.Item.Amount);
 
                         if (allowedChanges.Contains(nameof(ic.Value.Item.LockLevel)))
-                            itemNode.SelectSingleNode("attribute [@id='LockLevel']").Attributes[1].Value =
-                                ic.Value.Item.LockLevel;
+                            SetLsxAttributeValue(itemNode, "LockLevel", ic.Value.Item.LockLevel);
 
                         if (allowedChanges.Contains(nameof(ic.Value.Item.Vitality)))
                         {
-                            itemNode.SelectSingleNode("attribute [@id='Vitality']").Attributes[1].Value =
-                                ic.Value.Item.Vitality;
-                            itemNode.SelectSingleNode("attribute [@id='MaxVitalityPatchCheck']").Attributes[1].Value =
-                                ic.Value.Item.MaxVitalityPatchCheck;
+                            SetLsxAttributeValue(itemNode, "Vitality", ic.Value.Item.Vitality);
+                            SetLsxAttributeValue(itemNode, "MaxVitalityPatchCheck", ic.Value.Item.MaxVitalityPatchCheck);
                         }
 
                         if (allowedChanges.Contains(nameof(ic.Value.Item.ItemRarity)))
-                            itemNode.SelectSingleNode("attribute [@id='ItemType']").Attributes[1].Value =
-                                ic.Value.Item.ItemRarity.ToString();
+                            SetLsxAttributeValue(itemNode, "ItemType", ic.Value.Item.ItemRarity.ToString());
 
-                        // max durability cannot be changed
-                        //var node = itemNode.SelectSingleNode("attribute [@id='MaxDurabilityPatchCheck']");
-                        //if (allowedChanges.Contains(nameof(ic.Value.Item.Stats)) && node!=null)
-                        //{
-                        //    node.Attributes[1].Value = ic.Value.Item.MaxDurabilityPatchCheck;
-                        //}
+                        // MaxDurabilityPatchCheck: display-only — game derives real max from item data at runtime.
 
                         // check if has generation
                         if (allowedChanges.Contains(nameof(ic.Value.Item.Generation)) &&
@@ -488,7 +628,7 @@ namespace D_OS_Save_Editor
                                 childrenNode.AppendChild(boost);
                             }
 
-                            itemNode.SelectSingleNode("attribute [@id='IsGenerated']").Attributes[1].Value = "True";
+                            SetLsxAttributeValue(itemNode, "IsGenerated", "True");
                         }
 
                         // check if has stats
@@ -497,17 +637,12 @@ namespace D_OS_Save_Editor
                             ic.Value.Item.Stats == null)
                             continue;
 
-                        statsNode.SelectSingleNode("attribute [@id='Durability']").Attributes[1].Value =
-                            ic.Value.Item.Stats.Durability;
-                        statsNode.SelectSingleNode("attribute [@id='DurabilityCounter']").Attributes[1].Value =
-                            ic.Value.Item.Stats.DurabilityCounter;
-                        statsNode.SelectSingleNode("attribute [@id='RepairDurabilityPenalty']").Attributes[1].Value =
-                            ic.Value.Item.Stats.RepairDurabilityPenalty;
-                        statsNode.SelectSingleNode("attribute [@id='Level']").Attributes[1].Value =
-                            ic.Value.Item.Stats.Level;
-                        statsNode.SelectSingleNode("attribute [@id='ItemType']").Attributes[1].Value =
-                            ic.Value.Item.ItemType; // ItemType is taken from item.ItemType
-                        statsNode.SelectSingleNode("attribute [@id='IsIdentified']").Attributes[1].Value = "1";
+                        SetLsxAttributeValue(statsNode, "Durability", ic.Value.Item.Stats.Durability);
+                        SetLsxAttributeValue(statsNode, "DurabilityCounter", ic.Value.Item.Stats.DurabilityCounter);
+                        SetLsxAttributeValue(statsNode, "RepairDurabilityPenalty", ic.Value.Item.Stats.RepairDurabilityPenalty);
+                        SetLsxAttributeValue(statsNode, "Level", ic.Value.Item.Stats.Level);
+                        SetLsxAttributeValue(statsNode, "ItemType", ic.Value.Item.ItemType);
+                        SetLsxAttributeValue(statsNode, "IsIdentified", "1");
                     }
 
                 }

--- a/D-OS Save Editor/savegame/Player.cs
+++ b/D-OS Save Editor/savegame/Player.cs
@@ -214,6 +214,11 @@ namespace D_OS_Save_Editor
         public Item[] Items { get; set; }
 
         /// <summary>
+        /// Xml nodes for each entry in <see cref="Items"/> (same index as <see cref="Item.ItemXmlNodeIdx"/>). Used when writing item edits for nested inventories.
+        /// </summary>
+        public List<XmlNode> ItemXmlNodes { get; set; }
+
+        /// <summary>
         /// NOT IN USE. Amount of gold.
         /// </summary>
         public string Gold { get; set; }

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 The save editor will only work for the said game version. Do *NOT* use it for the `original D-OS` or `D-OS 2`.
 
+**This repository:** [github.com/phillenton/D-OS-Save-Editor](https://github.com/phillenton/D-OS-Save-Editor) — current development and releases.
+
+**Original project:** [github.com/AnthonyZJiang/D-OS-Save-Editor](https://github.com/AnthonyZJiang/D-OS-Save-Editor) (Anthony Jiang).
 
 For use and discussions, please head over to: [Larian Forum](http://larian.com/forums/ubbthreads.php?ubb=showflat&Number=644516#Post644516)
 
-Latest release: [alpha preview](https://github.com/tmxkn1/D-OS-Save-Editor/releases)
+Older published builds (pre-fork): [alpha preview @ tmxkn1](https://github.com/tmxkn1/D-OS-Save-Editor/releases).
 
 ----
 Credit goes to Norbyte and his [LSTools](https://github.com/Norbyte/lslib).

--- a/SAVE_FORMAT_NOTES.md
+++ b/SAVE_FORMAT_NOTES.md
@@ -1,0 +1,27 @@
+# Save / LSX notes (D:OS EE)
+
+## Example unpacked XML to inspect
+
+`GameSaves/Divinity Original Sin Enhanced Edition/SaveFiles/globals.lsx`
+
+(Path is relative to the **D-OS Game File Editor** workspace folder.)
+
+## Inventory `Item` nodes vs in-game names
+
+Character **inventory** `<node id="Item">` rows usually have **no** `attribute id="DisplayName"`. The friendly name you see in-game for a given `Stats` value (e.g. `SCROLL_Fireball_1`) comes from the **game’s data** (string tables / stats definitions), not from an extra string stored on that save row.
+
+`DisplayName` **does** appear elsewhere in `globals.lsx` (e.g. on **`Template`** nodes in level data), but those are not the same nodes as inventory items.
+
+## Same `Stats` (e.g. three `CONT_Backpack_A`) — what can still differ?
+
+If several items share **`Stats`** and the same **`CurrentTemplate` / `OriginalTemplate`** GUIDs, the save can still differ on fields such as:
+
+| Area | Examples (see your `globals.lsx`) |
+|------|-------------------------------------|
+| **`Flags`** | Same stats, different numeric `Flags` (e.g. `4227992` vs `33688`) — bit flags for item state. |
+| **`ItemMachine`** | Some instances include `Type`, `ItemState` / `TransactionID`; others have an empty `ItemMachine`. |
+| **`Key`** | Non-empty if the player renamed the item in-game. |
+| **`Inventory` / `Parent` / `Slot` / `owner`** | Which bag or character holds the item (different container instances). |
+| **Nested `Generation` / `Stats` / `VariableManager`** | Modifiers, identification, script variables. |
+
+So: there is **not** a second “display name” column on inventory items for the UI text. Differences you see between “backpack” vs “pouch” for the **same** `Stats` string are likely **flags**, **ItemMachine**, **rename (`Key`)**, or **game-side logic** reading template + state—not a missing `DisplayName` attribute in the save.

--- a/SortGenerationList/App.config
+++ b/SortGenerationList/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
     </startup>
 </configuration>

--- a/SortGenerationList/SortGenerationList.csproj
+++ b/SortGenerationList/SortGenerationList.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SortGenerationList</RootNamespace>
     <AssemblyName>SortGenerationList</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/UpdateCheck
+++ b/UpdateCheck
@@ -1,4 +1,4 @@
 HandShake={ABCQWEZXCrtyfghvbnUIOJKLNM}
 LatestVersion={v1.6.0}
-Link=linkStart{https://github.com/tmxkn1/D-OS-Save-Editor/releases}linkEnd
+Link=linkStart{https://github.com/phillenton/D-OS-Save-Editor/releases}linkEnd
 Msg=msgStart{Updated! v1.6.0. Meta info, descpritions for Abilities and more. }msgEnd

--- a/UpdateCheck1
+++ b/UpdateCheck1
@@ -1,4 +1,4 @@
 HandShake={ABCQWEZXCrtyfghvbnUIOJKLNM}
 LatestVersion={v1.6.0}
-Link=linkStart{https://github.com/tmxkn1/D-OS-Save-Editor/releases}linkEnd
+Link=linkStart{https://github.com/phillenton/D-OS-Save-Editor/releases}linkEnd
 Msg=msgStart{Updated! v1.6.0. Meta info, descpritions for Abilities and more. }msgEnd

--- a/scripts/create-upstream-pr.ps1
+++ b/scripts/create-upstream-pr.ps1
@@ -1,4 +1,5 @@
-# Creates a PR from this fork (feature/nested-containers) into AnthonyZJiang/D-OS-Save-Editor master.
+# OPTIONAL: Open a pull request from your fork into the original maintainer's repo (AnthonyZJiang/D-OS-Save-Editor).
+# Day-to-day work: push to origin — https://github.com/phillenton/D-OS-Save-Editor
 # Requires: GitHub CLI (`winget install GitHub.cli`) and `gh auth login` once.
 
 $ErrorActionPreference = "Stop"
@@ -27,7 +28,7 @@ Enhancements for **Divinity: Original Sin – Enhanced Edition** saves: full nes
 - **Amount:** `IsAmountEditable()` rules; extended gold names in `DataTable`.
 - **Docs:** `CHANGELOG.md`, `SAVE_FORMAT_NOTES.md`.
 
-Fork: `phillenton/d-os-save-file-editor` branch `feature/nested-containers` → upstream `master`.
+Fork: `phillenton/D-OS-Save-Editor` branch `feature/nested-containers` → original repo `master`.
 '@ | Set-Content -Path $bodyFile -Encoding UTF8
 
 gh pr create `

--- a/scripts/create-upstream-pr.ps1
+++ b/scripts/create-upstream-pr.ps1
@@ -1,0 +1,45 @@
+# Creates a PR from this fork (feature/nested-containers) into AnthonyZJiang/D-OS-Save-Editor master.
+# Requires: GitHub CLI (`winget install GitHub.cli`) and `gh auth login` once.
+
+$ErrorActionPreference = "Stop"
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "GitHub CLI (gh) not found. Install with: winget install GitHub.cli"
+}
+
+gh auth status 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Not authenticated. Run: gh auth login" -ForegroundColor Yellow
+    exit 1
+}
+
+# scripts/ lives under repo root
+$repoRoot = Split-Path $PSScriptRoot -Parent
+
+$bodyFile = Join-Path $env:TEMP "gh-pr-dos-body.md"
+@'
+## Summary
+Enhancements for **Divinity: Original Sin – Enhanced Edition** saves: full nested inventory support, reliable persistence of inventory edits to `globals.lsx`, and clearer inventory UI/session behavior.
+
+## Key changes
+- **Nested items:** BFS inventory walk (same order for parse and write); `ItemXmlNodeIdx` targets the correct XML node for nested containers.
+- **Save fix:** `WriteEditsToLsxAsync` reloads `globals.lsx`; item writes use **fresh** `XmlNode`s from a replayed BFS on that document. `WritePlayer` is sequential (no parallel DOM writes).
+- **LSX writes:** `SetLsxAttributeValue` sets the `value=` attribute reliably.
+- **UI:** Inventory `TreeView`, filters/search, **Apply** + pending labels; `TreeViewItem.Tag` synced after Apply; wider save dialog; equip slot (0–14) for paper doll; compact equipped marker; removed non-functional display-name row.
+- **Amount:** `IsAmountEditable()` rules; extended gold names in `DataTable`.
+- **Docs:** `CHANGELOG.md`, `SAVE_FORMAT_NOTES.md`.
+
+Fork: `phillenton/d-os-save-file-editor` branch `feature/nested-containers` → upstream `master`.
+'@ | Set-Content -Path $bodyFile -Encoding UTF8
+
+gh pr create `
+    --repo AnthonyZJiang/D-OS-Save-Editor `
+    --base master `
+    --head phillenton:feature/nested-containers `
+    --title "D:OS EE: nested inventory, item save fixes, inventory UX" `
+    --body-file $bodyFile
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "Done." -ForegroundColor Green
+}

--- a/scripts/create-upstream-pr.ps1
+++ b/scripts/create-upstream-pr.ps1
@@ -14,9 +14,6 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# scripts/ lives under repo root
-$repoRoot = Split-Path $PSScriptRoot -Parent
-
 $bodyFile = Join-Path $env:TEMP "gh-pr-dos-body.md"
 @'
 ## Summary

--- a/wishlist.md
+++ b/wishlist.md
@@ -1,0 +1,23 @@
+# D-OS Save Editor — wishlist / backlog
+
+Items are roughly priority-agnostic unless noted. Pick up in any order.
+
+## Done (reference)
+
+- Session vs disk dirty state (“Not saved to file”, close prompts)
+- Unapplied-edit labeling and Apply gating (character tabs + inventory)
+- Gold name filter / amount rules; armor amount locked like weapons
+
+## Backlog
+
+1. **Duplicate item** — copy a row (sensible rules: maybe exclude stackables / Unique where unsafe)
+2. **Delete inventory item** — remove any item row from inventory
+3. **Nested containers** — open bags / pouches / backpacks (scrolls, arrows, organization)
+4. **Rename items** — especially pouches; optionally add new containers
+5. **Inventory icons** — resolve from user-selected local D:OS EE install (no bundled Larian assets)
+6. **Auto-detect game install** — registry / Steam–GOG-style paths (parallel to save-folder logic)
+7. **Remove character** — drop a party member / stuck NPC from the save
+8. **Main character** — detect main PC and autoselect on load (not alphabetical)
+9. **Skills tab** — UI tab to edit memorized skills
+10. **Story / log tab** — UI tab to edit story quests (and related log/story state as exposed by the save format)
+11. **D:OS 2** — Divinity: Original Sin 2 save support


### PR DESCRIPTION
﻿## Summary
Enhancements for **Divinity: Original Sin – Enhanced Edition** saves: full nested inventory support, reliable persistence of inventory edits to `globals.lsx`, and clearer inventory UI/session behavior.

## Key changes
- **Nested items:** BFS inventory walk (same order for parse and write); `ItemXmlNodeIdx` targets the correct XML node for nested containers.
- **Save fix:** `WriteEditsToLsxAsync` reloads `globals.lsx`; item writes use **fresh** `XmlNode`s from a replayed BFS on that document. `WritePlayer` is sequential (no parallel DOM writes).
- **LSX writes:** `SetLsxAttributeValue` sets the `value=` attribute reliably.
- **UI:** Inventory `TreeView`, filters/search, **Apply** + pending labels; `TreeViewItem.Tag` synced after Apply; wider save dialog; equip slot (0–14) for paper doll; compact equipped marker; removed non-functional display-name row.
- **Amount:** `IsAmountEditable()` rules; extended gold names in `DataTable`.
- **Docs:** `CHANGELOG.md`, `SAVE_FORMAT_NOTES.md`.

Branch pushed to fork `phillenton/D-OS-Save-Editor` (also mirrored at `phillenton/d-os-save-file-editor`).
